### PR TITLE
Use Specific Version of `image`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.2.2"
 authors = ["Andrew Buntine Of Doom <bunts@hhd.com.au>"]
 
 [dependencies]
-image = "*"
+image = "0.5.1"


### PR DESCRIPTION
Wildcard dependencies are evil.

(This will be treated like "^0.5.1", i.e., "≥0.5.1 and < 0.6.0".)
