### PR TITLE
Add some lints and reformat some code

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,25 @@
+# EditorConfig helps developers define and maintain consistent
+# coding styles between different editors and IDEs
+# editorconfig.org
+
+root = true
+
+
+[*]
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.rs]
+indent_style = space
+indent_size = 4
+
+[*.toml]
+indent_style = space
+indent_size = 4
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+sudo: false
+language: rust
+rust:
+- nightly
+- beta
+- stable
+matrix:
+  allow_failures:
+  - rust: nightly
+before_script:
+- |
+  pip install 'travis-cargo<0.2' --user &&
+  export PATH=$HOME/.local/bin:$PATH
+script:
+- |
+  travis-cargo build &&
+  travis-cargo test &&
+  travis-cargo bench &&
+  travis-cargo --only stable doc
+# addons:
+#   apt:
+#     packages:
+#     - libcurl4-openssl-dev
+#     - libelf-dev
+#     - libdw-dev
+#after_success:
+#- travis-cargo --only stable doc-upload
+#- env COVERAGE_TESTING=1 travis-cargo coveralls --no-sudo
+notifications:
+  email:
+    on_success: never
+env:
+  global:
+  - TRAVIS_CARGO_NIGHTLY_FEATURE=dev
+  # - secure:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,9 @@ exclude = [
 ]
 
 [features]
-
 ascii = []
+dev = ["clippy"]
 
 [dependencies]
 image = {version = "0.5.1", optional = true}
+clippy = {version = "0.0.24", optional = true}

--- a/src/generators/ascii.rs
+++ b/src/generators/ascii.rs
@@ -18,7 +18,10 @@ pub const ASCII_CHARS: [char; 2] = [' ', '#'];
 impl ASCII {
     /// Returns a new ASCII with default values.
     pub fn new() -> ASCII {
-        ASCII{height: 10, xdim: 1}
+        ASCII {
+            height: 10,
+            xdim: 1,
+        }
     }
 
     fn generate_row(&self, barcode: &[u8]) -> String {

--- a/src/generators/ascii.rs
+++ b/src/generators/ascii.rs
@@ -55,7 +55,7 @@ mod tests {
 
     #[test]
     fn ean_13_as_ascii() {
-        let ean13 = EAN13::new("750103131130".to_string()).unwrap();
+        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean13.encode()[..]).unwrap();
 
@@ -71,12 +71,12 @@ mod tests {
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn ean_13_as_ascii_small_height_double_width() {
-        let ean13 = EAN13::new("750103131130".to_string()).unwrap();
+        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
         let ascii = ASCII{height: 6, xdim: 2};
         let generated = ascii.generate(&ean13.encode()[..]).unwrap();
 
@@ -88,12 +88,12 @@ mod tests {
 ##  ##  ####      ##  ##    ######    ####    ##  ##    ######  ########  ##  ####    ####  ##  ##  ##        ##  ####    ####  ####    ####  ##        ##  ######    ##  ######  ##    ##  ##
 ##  ##  ####      ##  ##    ######    ####    ##  ##    ######  ########  ##  ####    ####  ##  ##  ##        ##  ####    ####  ####    ####  ##        ##  ######    ##  ######  ##    ##  ##
 ##  ##  ####      ##  ##    ######    ####    ##  ##    ######  ########  ##  ####    ####  ##  ##  ##        ##  ####    ####  ####    ####  ##        ##  ######    ##  ######  ##    ##  ##
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn ean_8_as_ascii() {
-        let ean8 = EAN8::new("1234567".to_string()).unwrap();
+        let ean8 = EAN8::new("1234567".to_owned()).unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean8.encode()[..]).unwrap();
 
@@ -109,12 +109,12 @@ mod tests {
 # #  ##  #  #  ## #### # #   ## # # #  ### # #    #   #  ###  # # #
 # #  ##  #  #  ## #### # #   ## # # #  ### # #    #   #  ###  # # #
 # #  ##  #  #  ## #### # #   ## # # #  ### # #    #   #  ###  # # #
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn ean_8_as_ascii_small_height_double_width() {
-        let ean8 = EAN8::new("1234567".to_string()).unwrap();
+        let ean8 = EAN8::new("1234567".to_owned()).unwrap();
         let ascii = ASCII{height: 5, xdim: 2};
         let generated = ascii.generate(&ean8.encode()[..]).unwrap();
 
@@ -125,12 +125,12 @@ mod tests {
 ##  ##    ####    ##    ##    ####  ########  ##  ##      ####  ##  ##  ##    ######  ##  ##        ##      ##    ######    ##  ##  ##
 ##  ##    ####    ##    ##    ####  ########  ##  ##      ####  ##  ##  ##    ######  ##  ##        ##      ##    ######    ##  ##  ##
 ##  ##    ####    ##    ##    ####  ########  ##  ##      ####  ##  ##  ##    ######  ##  ##        ##      ##    ######    ##  ##  ##
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn code_39_as_ascii() {
-        let code39 = Code39::new("TEST8052".to_string()).unwrap();
+        let code39 = Code39::new("TEST8052".to_owned()).unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&code39.encode()[..]).unwrap();
 
@@ -146,12 +146,12 @@ mod tests {
 #  # ## ## # # # ## ##  # ## # ##  # # # ## # ##  # # # ## ##  # ## #  # ## # # #  ## ## # ## #  ## # # # ##  # # ## #  # ## ## #
 #  # ## ## # # # ## ##  # ## # ##  # # # ## # ##  # # # ## ##  # ## #  # ## # # #  ## ## # ## #  ## # # # ##  # # ## #  # ## ## #
 #  # ## ## # # # ## ##  # ## # ##  # # # ## # ##  # # # ## ##  # ## #  # ## # # #  ## ## # ## #  ## # # # ##  # # ## #  # ## ## #
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn code_39_as_ascii_small_height_double_weight() {
-        let code39 = Code39::new("1234".to_string()).unwrap();
+        let code39 = Code39::new("1234".to_owned()).unwrap();
         let ascii = ASCII{height: 7, xdim: 2};
         let generated = ascii.generate(&code39.encode()[..]).unwrap();
 
@@ -164,12 +164,12 @@ mod tests {
 ##    ##  ####  ####  ##  ####  ##    ##  ##  ####  ##  ####    ##  ##  ####  ####  ####    ##  ##  ##  ##  ##    ####  ##  ####  ##    ##  ####  ####  ##
 ##    ##  ####  ####  ##  ####  ##    ##  ##  ####  ##  ####    ##  ##  ####  ####  ####    ##  ##  ##  ##  ##    ####  ##  ####  ##    ##  ####  ####  ##
 ##    ##  ####  ####  ##  ####  ##    ##  ##  ####  ##  ####    ##  ##  ####  ####  ####    ##  ##  ##  ##  ##    ####  ##  ####  ##    ##  ####  ####  ##
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn ean2_as_ascii() {
-        let ean2 = EANSUPP::new("34".to_string()).unwrap();
+        let ean2 = EANSUPP::new("34".to_owned()).unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean2.encode()[..]).unwrap();
 
@@ -185,12 +185,12 @@ mod tests {
 # ## #    # # #   ##
 # ## #    # # #   ##
 # ## #    # # #   ##
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn ean5_as_ascii() {
-        let ean5 = EANSUPP::new("50799".to_string()).unwrap();
+        let ean5 = EANSUPP::new("50799".to_owned()).unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean5.encode()[..]).unwrap();
 
@@ -206,12 +206,12 @@ mod tests {
 # ## ##   # # #  ### #  #   # #   # ## #   # ##
 # ## ##   # # #  ### #  #   # #   # ## #   # ##
 # ## ##   # # #  ### #  #   # #   # ## #   # ##
-".trim().to_string());
+".trim().to_owned());
     }
 
     #[test]
     fn itf_as_ascii() {
-        let itf = TF::interleaved("12345".to_string()).unwrap();
+        let itf = TF::interleaved("12345".to_owned()).unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&itf.encode()[..]).unwrap();
 
@@ -227,6 +227,6 @@ mod tests {
 # # ### #   # # ###   ### ### #   # #   ### # ### #   #   ## #
 # # ### #   # # ###   ### ### #   # #   ### # ### #   #   ## #
 # # ### #   # # ###   ### ### #   # #   ### # ### #   #   ## #
-".trim().to_string());
+".trim().to_owned());
     }
 }

--- a/src/generators/image.rs
+++ b/src/generators/image.rs
@@ -1,4 +1,4 @@
-//! This module provides types for generating image representations of barcodes. 
+//! This module provides types for generating image representations of barcodes.
 
 extern crate image;
 
@@ -36,17 +36,26 @@ pub enum Image {
 impl Image {
     /// Returns a new GIF with default values.
     pub fn gif() -> Image {
-        Image::GIF{height: 80, xdim: 1}
+        Image::GIF {
+            height: 80,
+            xdim: 1,
+        }
     }
 
     /// Returns a new PNG with default values.
     pub fn png() -> Image {
-        Image::PNG{height: 80, xdim: 1}
+        Image::PNG {
+            height: 80,
+            xdim: 1,
+        }
     }
 
     /// Returns a new PNG with default values.
     pub fn jpeg() -> Image {
-        Image::JPEG{height: 80, xdim: 1}
+        Image::JPEG {
+            height: 80,
+            xdim: 1,
+        }
     }
 
     /// Generates the given barcode. Returns a usize indicating the number of bytes written.
@@ -60,7 +69,7 @@ impl Image {
         let width = (barcode.len() as u32) * (xdim * IMAGE_BAR_WIDTH);
         let mut buffer = ImageBuffer::new(width, height);
         let mut pos = 0;
-        
+
         for y in 0..height {
             for &b in barcode {
                 let size = xdim * IMAGE_BAR_WIDTH;
@@ -121,7 +130,10 @@ mod tests {
         let mut path = open_file("ean13.png");
 
         let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
-        let png = Image::PNG{height: 100, xdim: 1};
+        let png = Image::PNG {
+            height: 100,
+            xdim: 1,
+        };
         let generated = png.generate(&ean13.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 9500);
@@ -132,7 +144,10 @@ mod tests {
         let mut path = open_file("ean13.jpg");
 
         let ean13 = EAN13::new("999988881234".to_owned()).unwrap();
-        let jpeg = Image::JPEG{height: 100, xdim: 3};
+        let jpeg = Image::JPEG {
+            height: 100,
+            xdim: 3,
+        };
         let generated = jpeg.generate(&ean13.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 28500);
@@ -143,7 +158,10 @@ mod tests {
         let mut path = open_file("code39.png");
 
         let code39 = Code39::new("ILOVEMEL".to_owned()).unwrap();
-        let png = Image::PNG{height: 60, xdim: 1};
+        let png = Image::PNG {
+            height: 60,
+            xdim: 1,
+        };
         let generated = png.generate(&code39.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 7740);
@@ -154,7 +172,10 @@ mod tests {
         let mut path = open_file("code39.gif");
 
         let code39 = Code39::new("WIKIPEDIA".to_owned()).unwrap();
-        let gif = Image::GIF{height: 60, xdim: 1};
+        let gif = Image::GIF {
+            height: 60,
+            xdim: 1,
+        };
         let generated = gif.generate(&code39.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 8520);
@@ -165,7 +186,10 @@ mod tests {
         let mut path = open_file("code39.jpg");
 
         let code39 = Code39::new("SWAGLORDTHE3RD".to_owned()).unwrap();
-        let jpeg = Image::JPEG{height: 160, xdim: 1};
+        let jpeg = Image::JPEG {
+            height: 160,
+            xdim: 1,
+        };
         let generated = jpeg.generate(&code39.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 33120);
@@ -176,7 +200,10 @@ mod tests {
         let mut path = open_file("ean8.png");
 
         let ean8 = EAN8::new("5512345".to_owned()).unwrap();
-        let png = Image::PNG{height: 70, xdim: 2};
+        let png = Image::PNG {
+            height: 70,
+            xdim: 2,
+        };
         let generated = png.generate(&ean8.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 9380);
@@ -187,7 +214,10 @@ mod tests {
         let mut path = open_file("ean8.gif");
 
         let ean8 = EAN8::new("9992227".to_owned()).unwrap();
-        let gif = Image::GIF{height: 70, xdim: 2};
+        let gif = Image::GIF {
+            height: 70,
+            xdim: 2,
+        };
         let generated = gif.generate(&ean8.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 9380);
@@ -198,7 +228,10 @@ mod tests {
         let mut path = open_file("ean8.jpg");
 
         let ean8 = EAN8::new("9992227".to_owned()).unwrap();
-        let jpeg = Image::JPEG{height: 70, xdim: 2};
+        let jpeg = Image::JPEG {
+            height: 70,
+            xdim: 2,
+        };
         let generated = jpeg.generate(&ean8.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 9380);
@@ -209,7 +242,10 @@ mod tests {
         let mut path = open_file("ean2.png");
 
         let ean2 = EANSUPP::new("94".to_owned()).unwrap();
-        let png = Image::PNG{height: 70, xdim: 2};
+        let png = Image::PNG {
+            height: 70,
+            xdim: 2,
+        };
         let generated = png.generate(&ean2.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 2800);
@@ -220,7 +256,10 @@ mod tests {
         let mut path = open_file("ean5.gif");
 
         let ean5 = EANSUPP::new("51234".to_owned()).unwrap();
-        let gif = Image::GIF{height: 70, xdim: 2};
+        let gif = Image::GIF {
+            height: 70,
+            xdim: 2,
+        };
         let generated = gif.generate(&ean5.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 6580);
@@ -231,7 +270,10 @@ mod tests {
         let mut path = open_file("ean5.jpg");
 
         let ean5 = EANSUPP::new("51574".to_owned()).unwrap();
-        let jpeg = Image::JPEG{height: 140, xdim: 5};
+        let jpeg = Image::JPEG {
+            height: 140,
+            xdim: 5,
+        };
         let generated = jpeg.generate(&ean5.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 32900);
@@ -242,7 +284,10 @@ mod tests {
         let mut path = open_file("itf.png");
 
         let itf = TF::interleaved("1234567".to_owned()).unwrap();
-        let png = Image::PNG{height: 100, xdim: 2};
+        let png = Image::PNG {
+            height: 100,
+            xdim: 2,
+        };
         let generated = png.generate(&itf.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 16000);
@@ -253,7 +298,10 @@ mod tests {
         let mut path = open_file("stf.png");
 
         let stf = TF::standard("1234567".to_owned()).unwrap();
-        let png = Image::PNG{height: 100, xdim: 2};
+        let png = Image::PNG {
+            height: 100,
+            xdim: 2,
+        };
         let generated = png.generate(&stf.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 22800);
@@ -264,7 +312,10 @@ mod tests {
         let mut path = open_file("itf.gif");
 
         let itf = TF::interleaved("98766543561".to_owned()).unwrap();
-        let gif = Image::GIF{height: 130, xdim: 1};
+        let gif = Image::GIF {
+            height: 130,
+            xdim: 1,
+        };
         let generated = gif.generate(&itf.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 15080);
@@ -275,7 +326,10 @@ mod tests {
         let mut path = open_file("itf.jpg");
 
         let itf = TF::interleaved("98766543561".to_owned()).unwrap();
-        let jpeg = Image::JPEG{height: 130, xdim: 1};
+        let jpeg = Image::JPEG {
+            height: 130,
+            xdim: 1,
+        };
         let generated = jpeg.generate(&itf.encode()[..], &mut path).unwrap();
 
         assert_eq!(generated, 15080);

--- a/src/generators/image.rs
+++ b/src/generators/image.rs
@@ -109,7 +109,7 @@ mod tests {
     fn ean_13_as_gif() {
         let mut path = open_file("ean13.gif");
 
-        let ean13 = EAN13::new("750103131130".to_string()).unwrap();
+        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
         let gif = Image::gif();
         let generated = gif.generate(&ean13.encode()[..], &mut path).unwrap();
 
@@ -120,7 +120,7 @@ mod tests {
     fn ean_13_as_png() {
         let mut path = open_file("ean13.png");
 
-        let ean13 = EAN13::new("750103131130".to_string()).unwrap();
+        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
         let png = Image::PNG{height: 100, xdim: 1};
         let generated = png.generate(&ean13.encode()[..], &mut path).unwrap();
 
@@ -131,7 +131,7 @@ mod tests {
     fn ean_13_as_jpeg() {
         let mut path = open_file("ean13.jpg");
 
-        let ean13 = EAN13::new("999988881234".to_string()).unwrap();
+        let ean13 = EAN13::new("999988881234".to_owned()).unwrap();
         let jpeg = Image::JPEG{height: 100, xdim: 3};
         let generated = jpeg.generate(&ean13.encode()[..], &mut path).unwrap();
 
@@ -142,7 +142,7 @@ mod tests {
     fn code39_as_png() {
         let mut path = open_file("code39.png");
 
-        let code39 = Code39::new("ILOVEMEL".to_string()).unwrap();
+        let code39 = Code39::new("ILOVEMEL".to_owned()).unwrap();
         let png = Image::PNG{height: 60, xdim: 1};
         let generated = png.generate(&code39.encode()[..], &mut path).unwrap();
 
@@ -153,7 +153,7 @@ mod tests {
     fn code39_as_gif() {
         let mut path = open_file("code39.gif");
 
-        let code39 = Code39::new("WIKIPEDIA".to_string()).unwrap();
+        let code39 = Code39::new("WIKIPEDIA".to_owned()).unwrap();
         let gif = Image::GIF{height: 60, xdim: 1};
         let generated = gif.generate(&code39.encode()[..], &mut path).unwrap();
 
@@ -164,7 +164,7 @@ mod tests {
     fn code39_as_jpeg() {
         let mut path = open_file("code39.jpg");
 
-        let code39 = Code39::new("SWAGLORDTHE3RD".to_string()).unwrap();
+        let code39 = Code39::new("SWAGLORDTHE3RD".to_owned()).unwrap();
         let jpeg = Image::JPEG{height: 160, xdim: 1};
         let generated = jpeg.generate(&code39.encode()[..], &mut path).unwrap();
 
@@ -175,7 +175,7 @@ mod tests {
     fn ean8_as_png() {
         let mut path = open_file("ean8.png");
 
-        let ean8 = EAN8::new("5512345".to_string()).unwrap();
+        let ean8 = EAN8::new("5512345".to_owned()).unwrap();
         let png = Image::PNG{height: 70, xdim: 2};
         let generated = png.generate(&ean8.encode()[..], &mut path).unwrap();
 
@@ -186,7 +186,7 @@ mod tests {
     fn ean8_as_gif() {
         let mut path = open_file("ean8.gif");
 
-        let ean8 = EAN8::new("9992227".to_string()).unwrap();
+        let ean8 = EAN8::new("9992227".to_owned()).unwrap();
         let gif = Image::GIF{height: 70, xdim: 2};
         let generated = gif.generate(&ean8.encode()[..], &mut path).unwrap();
 
@@ -197,7 +197,7 @@ mod tests {
     fn ean8_as_jpeg() {
         let mut path = open_file("ean8.jpg");
 
-        let ean8 = EAN8::new("9992227".to_string()).unwrap();
+        let ean8 = EAN8::new("9992227".to_owned()).unwrap();
         let jpeg = Image::JPEG{height: 70, xdim: 2};
         let generated = jpeg.generate(&ean8.encode()[..], &mut path).unwrap();
 
@@ -208,7 +208,7 @@ mod tests {
     fn ean2_as_png() {
         let mut path = open_file("ean2.png");
 
-        let ean2 = EANSUPP::new("94".to_string()).unwrap();
+        let ean2 = EANSUPP::new("94".to_owned()).unwrap();
         let png = Image::PNG{height: 70, xdim: 2};
         let generated = png.generate(&ean2.encode()[..], &mut path).unwrap();
 
@@ -219,7 +219,7 @@ mod tests {
     fn ean5_as_gif() {
         let mut path = open_file("ean5.gif");
 
-        let ean5 = EANSUPP::new("51234".to_string()).unwrap();
+        let ean5 = EANSUPP::new("51234".to_owned()).unwrap();
         let gif = Image::GIF{height: 70, xdim: 2};
         let generated = gif.generate(&ean5.encode()[..], &mut path).unwrap();
 
@@ -230,7 +230,7 @@ mod tests {
     fn ean5_as_jpeg() {
         let mut path = open_file("ean5.jpg");
 
-        let ean5 = EANSUPP::new("51574".to_string()).unwrap();
+        let ean5 = EANSUPP::new("51574".to_owned()).unwrap();
         let jpeg = Image::JPEG{height: 140, xdim: 5};
         let generated = jpeg.generate(&ean5.encode()[..], &mut path).unwrap();
 
@@ -241,7 +241,7 @@ mod tests {
     fn itf_as_png() {
         let mut path = open_file("itf.png");
 
-        let itf = TF::interleaved("1234567".to_string()).unwrap();
+        let itf = TF::interleaved("1234567".to_owned()).unwrap();
         let png = Image::PNG{height: 100, xdim: 2};
         let generated = png.generate(&itf.encode()[..], &mut path).unwrap();
 
@@ -252,7 +252,7 @@ mod tests {
     fn stf_as_png() {
         let mut path = open_file("stf.png");
 
-        let stf = TF::standard("1234567".to_string()).unwrap();
+        let stf = TF::standard("1234567".to_owned()).unwrap();
         let png = Image::PNG{height: 100, xdim: 2};
         let generated = png.generate(&stf.encode()[..], &mut path).unwrap();
 
@@ -263,7 +263,7 @@ mod tests {
     fn itf_as_gif() {
         let mut path = open_file("itf.gif");
 
-        let itf = TF::interleaved("98766543561".to_string()).unwrap();
+        let itf = TF::interleaved("98766543561".to_owned()).unwrap();
         let gif = Image::GIF{height: 130, xdim: 1};
         let generated = gif.generate(&itf.encode()[..], &mut path).unwrap();
 
@@ -274,7 +274,7 @@ mod tests {
     fn itf_as_jpeg() {
         let mut path = open_file("itf.jpg");
 
-        let itf = TF::interleaved("98766543561".to_string()).unwrap();
+        let itf = TF::interleaved("98766543561".to_owned()).unwrap();
         let jpeg = Image::JPEG{height: 130, xdim: 1};
         let generated = jpeg.generate(&itf.encode()[..], &mut path).unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,13 @@
 //! * JPEG (feature: `image`)
 //! * More coming! (PostScript, SVG, etc)
 
+#![warn(missing_docs,
+        missing_debug_implementations, missing_copy_implementations,
+        trivial_casts, trivial_numeric_casts,
+        unsafe_code,
+        unstable_features,
+        unused_import_braces, unused_qualifications)]
+
 #[cfg(feature = "image")]
 extern crate image;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,10 @@
         unstable_features,
         unused_import_braces, unused_qualifications)]
 
+#![cfg_attr(feature = "dev", allow(unstable_features))]
+#![cfg_attr(feature = "dev", feature(plugin))]
+#![cfg_attr(feature = "dev", plugin(clippy))]
+
 #[cfg(feature = "image")]
 extern crate image;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,11 +4,11 @@
 //! (for exporting to GIF, PNG, etc) or build your own.
 //!
 //! ## Current Support
-//! 
+//!
 //! The ultimate goal of Barcoders is to provide encoding support for all major (and many not-so-major) symbologies.
-//! 
+//!
 //! ### Symbologies
-//! 
+//!
 //! * EAN-13
 //!   * UPC-A
 //!   * JAN
@@ -22,12 +22,12 @@
 //!   * Interleaved (ITF)
 //!   * Standard (STF)
 //! * More coming!
-//! 
+//!
 //! ### Generators
 //!
 //! Each generator is defined as an optional "feature" that must be opted-into in order for it's
 //! functionality to be compiled into your app.
-//! 
+//!
 //! * ASCII (feature: `ascii`)
 //! * PNG (feature: `image`)
 //! * GIF (feature: `image`)

--- a/src/sym/code39.rs
+++ b/src/sym/code39.rs
@@ -6,9 +6,9 @@
 //! popular in non-retail environments. It was one of the first symbologies to support encoding
 //! of the ASCII alphabet.
 
-use ::sym::Parse;
-use ::sym::EncodedBarcode;
-use ::sym::helpers;
+use sym::Parse;
+use sym::EncodedBarcode;
+use sym::helpers;
 use std::ops::Range;
 
 // Character -> Binary mappings for each of the 43 allowable character.
@@ -41,9 +41,14 @@ pub struct Code39 {
 }
 
 impl Code39 {
-   fn init(data: String, checksum: bool) -> Result<Code39, String> {
+    fn init(data: String, checksum: bool) -> Result<Code39, String> {
         match Code39::parse(data) {
-            Ok(d) => Ok(Code39{data: d.chars().collect(), checksum: checksum}),
+            Ok(d) => {
+                Ok(Code39 {
+                    data: d.chars().collect(),
+                    checksum: checksum,
+                })
+            }
             Err(e) => Err(e),
         }
     }
@@ -85,7 +90,7 @@ impl Code39 {
     }
 
     fn char_encoding(&self, c: &char) -> [u8; 12] {
-         match CODE39_CHARS.iter().find(|&ch| ch.0 == *c) {
+        match CODE39_CHARS.iter().find(|&ch| ch.0 == *c) {
             Some(&(_, enc)) => enc,
             None => panic!(format!("Unknown char: {}", c)),
         }
@@ -117,10 +122,7 @@ impl Code39 {
     pub fn encode(&self) -> EncodedBarcode {
         let guard = &CODE39_GUARD[..];
 
-        helpers::join_slices(&[
-            guard,
-            &self.payload()[..],
-            guard][..])
+        helpers::join_slices(&[guard, &self.payload()[..], guard][..])
     }
 }
 

--- a/src/sym/code39.rs
+++ b/src/sym/code39.rs
@@ -34,6 +34,7 @@ const CODE39_CHARS: [(char, [u8; 12]); 43] = [
 const CODE39_GUARD: [u8; 12] = [1, 0, 0, 1, 0, 1, 1, 0, 1, 1, 0, 1];
 
 /// The Code39 barcode type.
+#[derive(Debug)]
 pub struct Code39 {
     data: Vec<char>,
     pub checksum: bool,

--- a/src/sym/code39.rs
+++ b/src/sym/code39.rs
@@ -147,56 +147,56 @@ mod tests {
 
     #[test]
     fn new_code39() {
-        let code39 = Code39::new("12345".to_string());
+        let code39 = Code39::new("12345".to_owned());
 
         assert!(code39.is_ok());
     }
 
     #[test]
     fn invalid_data_code39() {
-        let code39 = Code39::new("1212s".to_string());
+        let code39 = Code39::new("1212s".to_owned());
 
         assert!(code39.is_err());
     }
 
     #[test]
     fn invalid_len_code39() {
-        let code39 = Code39::new("".to_string());
+        let code39 = Code39::new("".to_owned());
 
         assert!(code39.is_err());
     }
 
     #[test]
     fn code39_raw_data() {
-        let code39 = Code39::new("12345".to_string()).unwrap();
+        let code39 = Code39::new("12345".to_owned()).unwrap();
 
         assert_eq!(code39.raw_data(), &['1', '2', '3', '4', '5']);
     }
 
     #[test]
     fn code39_encode() {
-        let code391 = Code39::new("1234".to_string()).unwrap();
-        let code392 = Code39::new("983RD512".to_string()).unwrap();
-        let code393 = Code39::new("TEST8052".to_string()).unwrap();
+        let code391 = Code39::new("1234".to_owned()).unwrap();
+        let code392 = Code39::new("983RD512".to_owned()).unwrap();
+        let code393 = Code39::new("TEST8052".to_owned()).unwrap();
 
-        assert_eq!(collapse_vec(code391.encode()), "10010110110101101001010110101100101011011011001010101010011010110100101101101".to_string());
-        assert_eq!(collapse_vec(code392.encode()), "100101101101010110010110101101001011010110110010101011010101100101010110010110110100110101011010010101101011001010110100101101101".to_string());
-        assert_eq!(collapse_vec(code393.encode()), "100101101101010101101100101101011001010101101011001010101101100101101001011010101001101101011010011010101011001010110100101101101".to_string());
+        assert_eq!(collapse_vec(code391.encode()), "10010110110101101001010110101100101011011011001010101010011010110100101101101".to_owned());
+        assert_eq!(collapse_vec(code392.encode()), "100101101101010110010110101101001011010110110010101011010101100101010110010110110100110101011010010101101011001010110100101101101".to_owned());
+        assert_eq!(collapse_vec(code393.encode()), "100101101101010101101100101101011001010101101011001010101101100101101001011010101001101101011010011010101011001010110100101101101".to_owned());
     }
 
     #[test]
     fn code39_encode_with_checksum() {
-        let code391 = Code39::with_checksum("1234".to_string()).unwrap();
-        let code392 = Code39::with_checksum("983RD512".to_string()).unwrap();
+        let code391 = Code39::with_checksum("1234".to_owned()).unwrap();
+        let code392 = Code39::with_checksum("983RD512".to_owned()).unwrap();
 
-        assert_eq!(collapse_vec(code391.encode()), "100101101101011010010101101011001010110110110010101010100110101101101010010110100101101101".to_string());
-        assert_eq!(collapse_vec(code392.encode()), "1001011011010101100101101011010010110101101100101010110101011001010101100101101101001101010110100101011010110010101101011011010010100101101101".to_string());
+        assert_eq!(collapse_vec(code391.encode()), "100101101101011010010101101011001010110110110010101010100110101101101010010110100101101101".to_owned());
+        assert_eq!(collapse_vec(code392.encode()), "1001011011010101100101101011010010110101101100101010110101011001010101100101101101001101010110100101011010110010101101011011010010100101101101".to_owned());
     }
 
     #[test]
     fn code39_checksum_calculation() {
-        let code391 = Code39::new("1234".to_string()).unwrap(); // Check char: 'A'
-        let code392 = Code39::new("159AZ".to_string()).unwrap(); // Check char: 'H'
+        let code391 = Code39::new("1234".to_owned()).unwrap(); // Check char: 'A'
+        let code392 = Code39::new("159AZ".to_owned()).unwrap(); // Check char: 'H'
 
         assert_eq!(code391.checksum_char().unwrap(), 'A');
         assert_eq!(code392.checksum_char().unwrap(), 'H');

--- a/src/sym/ean13.rs
+++ b/src/sym/ean13.rs
@@ -171,70 +171,70 @@ mod tests {
 
     #[test]
     fn new_ean13() {
-        let ean13 = EAN13::new("123456123456".to_string());
+        let ean13 = EAN13::new("123456123456".to_owned());
 
         assert!(ean13.is_ok());
     }
 
     #[test]
     fn new_bookland() {
-        let bookland = Bookland::new("978456123456".to_string());
+        let bookland = Bookland::new("978456123456".to_owned());
 
         assert!(bookland.is_ok());
     }
 
     #[test]
     fn invalid_data_ean13() {
-        let ean13 = EAN13::new("1234er123412".to_string());
+        let ean13 = EAN13::new("1234er123412".to_owned());
 
         assert!(ean13.is_err());
     }
 
     #[test]
     fn invalid_len_ean13() {
-        let ean13 = EAN13::new("1111112222222333333".to_string());
+        let ean13 = EAN13::new("1111112222222333333".to_owned());
 
         assert!(ean13.is_err());
     }
 
     #[test]
     fn ean13_raw_data() {
-        let ean13 = EAN13::new("123456123456".to_string()).unwrap();
+        let ean13 = EAN13::new("123456123456".to_owned()).unwrap();
 
         assert_eq!(ean13.raw_data(), &[1,2,3,4,5,6,1,2,3,4,5,6]);
     }
 
     #[test]
     fn ean13_encode_as_upca() {
-        let ean131 = UPCA::new("012345612345".to_string()).unwrap(); // Check digit: 8
-        let ean132 = UPCA::new("000118999561".to_string()).unwrap(); // Check digit: 3
+        let ean131 = UPCA::new("012345612345".to_owned()).unwrap(); // Check digit: 8
+        let ean132 = UPCA::new("000118999561".to_owned()).unwrap(); // Check digit: 3
 
-        assert_eq!(collapse_vec(ean131.encode()), "10100110010010011011110101000110110001010111101010110011011011001000010101110010011101001000101".to_string());
-        assert_eq!(collapse_vec(ean132.encode()), "10100011010001101001100100110010110111000101101010111010011101001001110101000011001101000010101".to_string());
+        assert_eq!(collapse_vec(ean131.encode()), "10100110010010011011110101000110110001010111101010110011011011001000010101110010011101001000101".to_owned());
+        assert_eq!(collapse_vec(ean132.encode()), "10100011010001101001100100110010110111000101101010111010011101001001110101000011001101000010101".to_owned());
     }
 
     #[test]
     fn ean13_encode_as_bookland() {
-        let bookland1 = Bookland::new("978345612345".to_string()).unwrap(); // Check digit: 5
-        let bookland2 = Bookland::new("978118999561".to_string()).unwrap(); // Check digit: 5
+        let bookland1 = Bookland::new("978345612345".to_owned()).unwrap(); // Check digit: 5
+        let bookland2 = Bookland::new("978118999561".to_owned()).unwrap(); // Check digit: 5
 
-        assert_eq!(collapse_vec(bookland1.encode()), "10101110110001001010000101000110111001010111101010110011011011001000010101110010011101001110101".to_string());
-        assert_eq!(collapse_vec(bookland2.encode()), "10101110110001001011001100110010001001000101101010111010011101001001110101000011001101001110101".to_string());
+        assert_eq!(collapse_vec(bookland1.encode()), "10101110110001001010000101000110111001010111101010110011011011001000010101110010011101001110101".to_owned());
+        assert_eq!(collapse_vec(bookland2.encode()), "10101110110001001011001100110010001001000101101010111010011101001001110101000011001101001110101".to_owned());
     }
 
     #[test]
     fn ean13_encode() {
-        let ean131 = EAN13::new("750103131130".to_string()).unwrap(); // Check digit: 5
-        let ean132 = EAN13::new("983465123499".to_string()).unwrap(); // Check digit: 5
+        let ean131 = EAN13::new("750103131130".to_owned()).unwrap(); // Check digit: 5
+        let ean132 = EAN13::new("983465123499".to_owned()).unwrap(); // Check digit: 5
 
-        assert_eq!(collapse_vec(ean131.encode()), "10101100010100111001100101001110111101011001101010100001011001101100110100001011100101110100101".to_string());
-        assert_eq!(collapse_vec(ean132.encode()), "10101101110100001001110101011110111001001100101010110110010000101011100111010011101001000010101".to_string());
+        assert_eq!(collapse_vec(ean131.encode()), "10101100010100111001100101001110111101011001101010100001011001101100110100001011100101110100101".to_owned());
+        assert_eq!(collapse_vec(ean132.encode()), "10101101110100001001110101011110111001001100101010110110010000101011100111010011101001000010101".to_owned());
     }
 
     #[test]
     fn ean13_as_upca_checksum_calculation() {
-        let ean131 = UPCA::new("003600029145".to_string()).unwrap(); // Check digit: 2
-        let ean132 = UPCA::new("012345612345".to_string()).unwrap(); // Check digit: 8
+        let ean131 = UPCA::new("003600029145".to_owned()).unwrap(); // Check digit: 2
+        let ean132 = UPCA::new("012345612345".to_owned()).unwrap(); // Check digit: 8
 
         assert_eq!(ean131.checksum_digit(), 2);
         assert_eq!(ean132.checksum_digit(), 8);
@@ -242,8 +242,8 @@ mod tests {
 
     #[test]
     fn ean13_as_bookland_checksum_calculation() {
-        let bookland1 = Bookland::new("978600029145".to_string()).unwrap(); // Check digit: 7
-        let bookland2 = Bookland::new("978345612345".to_string()).unwrap(); // Check digit: 5
+        let bookland1 = Bookland::new("978600029145".to_owned()).unwrap(); // Check digit: 7
+        let bookland2 = Bookland::new("978345612345".to_owned()).unwrap(); // Check digit: 5
 
         assert_eq!(bookland1.checksum_digit(), 7);
         assert_eq!(bookland2.checksum_digit(), 5);
@@ -251,8 +251,8 @@ mod tests {
 
     #[test]
     fn ean13_checksum_calculation() {
-        let ean131 = EAN13::new("457567816412".to_string()).unwrap(); // Check digit: 6
-        let ean132 = EAN13::new("953476324586".to_string()).unwrap(); // Check digit: 2
+        let ean131 = EAN13::new("457567816412".to_owned()).unwrap(); // Check digit: 6
+        let ean132 = EAN13::new("953476324586".to_owned()).unwrap(); // Check digit: 2
 
         assert_eq!(ean131.checksum_digit(), 6);
         assert_eq!(ean132.checksum_digit(), 2);

--- a/src/sym/ean13.rs
+++ b/src/sym/ean13.rs
@@ -46,6 +46,7 @@ pub const EAN_MIDDLE_GUARD: [u8; 5] = [0,1,0,1,0];
 pub const EAN_RIGHT_GUARD: [u8; 3] = [1,0,1];
 
 /// The EAN-13 barcode type.
+#[derive(Debug)]
 pub struct EAN13 {
     data: Vec<u8>,
 }

--- a/src/sym/ean13.rs
+++ b/src/sym/ean13.rs
@@ -8,9 +8,9 @@
 //!   * Bookland
 //!   * JAN
 
-use ::sym::Parse;
-use ::sym::EncodedBarcode;
-use ::sym::helpers;
+use sym::Parse;
+use sym::EncodedBarcode;
+use sym::helpers;
 use std::ops::Range;
 use std::char;
 
@@ -41,9 +41,9 @@ const PARITY: [[usize; 5]; 10] = [
 
 /// The patterns for the guards. These are the separators that often stick down when
 /// a barcode is printed.
-pub const EAN_LEFT_GUARD: [u8; 3] = [1,0,1];
-pub const EAN_MIDDLE_GUARD: [u8; 5] = [0,1,0,1,0];
-pub const EAN_RIGHT_GUARD: [u8; 3] = [1,0,1];
+pub const EAN_LEFT_GUARD: [u8; 3] = [1, 0, 1];
+pub const EAN_MIDDLE_GUARD: [u8; 5] = [0, 1, 0, 1, 0];
+pub const EAN_RIGHT_GUARD: [u8; 3] = [1, 0, 1];
 
 /// The EAN-13 barcode type.
 #[derive(Debug)]
@@ -69,8 +69,10 @@ impl EAN13 {
     pub fn new(data: String) -> Result<EAN13, String> {
         match EAN13::parse(data) {
             Ok(d) => {
-                let digits = d.chars().map(|c| c.to_digit(10).expect("Unknown character") as u8).collect();
-                Ok(EAN13{data: digits})
+                let digits = d.chars()
+                              .map(|c| c.to_digit(10).expect("Unknown character") as u8)
+                              .collect();
+                Ok(EAN13 { data: digits })
             }
             Err(e) => Err(e),
         }
@@ -116,19 +118,19 @@ impl EAN13 {
 
     fn left_payload(&self) -> Vec<u8> {
         let slices: Vec<[u8; 7]> = self.left_digits()
-            .iter()
-            .zip(self.parity_mapping().iter())
-            .map(|(d, s)| self.char_encoding(*s, &d))
-            .collect();
+                                       .iter()
+                                       .zip(self.parity_mapping().iter())
+                                       .map(|(d, s)| self.char_encoding(*s, &d))
+                                       .collect();
 
         helpers::join_arrays(&slices[..])
     }
 
     fn right_payload(&self) -> Vec<u8> {
         let slices: Vec<[u8; 7]> = self.right_digits()
-            .iter()
-            .map(|d| self.char_encoding(2, &d))
-            .collect();
+                                       .iter()
+                                       .map(|d| self.char_encoding(2, &d))
+                                       .collect();
 
         helpers::join_arrays(&slices[..])
     }
@@ -136,14 +138,13 @@ impl EAN13 {
     /// Encodes the barcode.
     /// Returns a Vec<u8> of binary digits.
     pub fn encode(&self) -> EncodedBarcode {
-        helpers::join_slices(&[
-            &EAN_LEFT_GUARD[..],
-            &self.number_system_encoding()[..],
-            &self.left_payload()[..],
-            &EAN_MIDDLE_GUARD[..],
-            &self.right_payload()[..],
-            &self.checksum_encoding()[..],
-            &EAN_RIGHT_GUARD[..]][..])
+        helpers::join_slices(&[&EAN_LEFT_GUARD[..],
+                               &self.number_system_encoding()[..],
+                               &self.left_payload()[..],
+                               &EAN_MIDDLE_GUARD[..],
+                               &self.right_payload()[..],
+                               &self.checksum_encoding()[..],
+                               &EAN_RIGHT_GUARD[..]][..])
     }
 }
 
@@ -201,7 +202,7 @@ mod tests {
     fn ean13_raw_data() {
         let ean13 = EAN13::new("123456123456".to_owned()).unwrap();
 
-        assert_eq!(ean13.raw_data(), &[1,2,3,4,5,6,1,2,3,4,5,6]);
+        assert_eq!(ean13.raw_data(), &[1, 2, 3, 4, 5, 6, 1, 2, 3, 4, 5, 6]);
     }
 
     #[test]

--- a/src/sym/ean8.rs
+++ b/src/sym/ean8.rs
@@ -126,45 +126,45 @@ mod tests {
 
     #[test]
     fn new_ean8() {
-        let ean8 = EAN8::new("1234567".to_string());
+        let ean8 = EAN8::new("1234567".to_owned());
 
         assert!(ean8.is_ok());
     }
 
     #[test]
     fn invalid_data_ean8() {
-        let ean8 = EAN8::new("1234er123412".to_string());
+        let ean8 = EAN8::new("1234er123412".to_owned());
 
         assert!(ean8.is_err());
     }
 
     #[test]
     fn invalid_len_ean8() {
-        let ean8 = EAN8::new("1111112222222333333".to_string());
+        let ean8 = EAN8::new("1111112222222333333".to_owned());
 
         assert!(ean8.is_err());
     }
 
     #[test]
     fn ean8_raw_data() {
-        let ean8 = EAN8::new("1234567".to_string()).unwrap();
+        let ean8 = EAN8::new("1234567".to_owned()).unwrap();
 
         assert_eq!(ean8.raw_data(), &[1,2,3,4,5,6,7]);
     }
 
     #[test]
     fn ean8_encode() {
-        let ean81 = EAN8::new("5512345".to_string()).unwrap(); // Check digit: 7
-        let ean82 = EAN8::new("9834651".to_string()).unwrap(); // Check digit: 3
+        let ean81 = EAN8::new("5512345".to_owned()).unwrap(); // Check digit: 7
+        let ean82 = EAN8::new("9834651".to_owned()).unwrap(); // Check digit: 3
 
-        assert_eq!(collapse_vec(ean81.encode()), "1010110001011000100110010010011010101000010101110010011101000100101".to_string());
-        assert_eq!(collapse_vec(ean82.encode()), "1010001011011011101111010100011010101010000100111011001101010000101".to_string());
+        assert_eq!(collapse_vec(ean81.encode()), "1010110001011000100110010010011010101000010101110010011101000100101".to_owned());
+        assert_eq!(collapse_vec(ean82.encode()), "1010001011011011101111010100011010101010000100111011001101010000101".to_owned());
     }
 
     #[test]
     fn ean8_checksum_calculation() {
-        let ean81 = EAN8::new("4575678".to_string()).unwrap(); // Check digit: 8
-        let ean82 = EAN8::new("9534763".to_string()).unwrap(); // Check digit: 9
+        let ean81 = EAN8::new("4575678".to_owned()).unwrap(); // Check digit: 8
+        let ean82 = EAN8::new("9534763".to_owned()).unwrap(); // Check digit: 9
 
         assert_eq!(ean81.checksum_digit(), 8);
         assert_eq!(ean82.checksum_digit(), 9);

--- a/src/sym/ean8.rs
+++ b/src/sym/ean8.rs
@@ -12,6 +12,7 @@ use std::ops::Range;
 use std::char;
 
 /// The EAN-8 barcode type.
+#[derive(Debug)]
 pub struct EAN8 {
     data: Vec<u8>,
 }

--- a/src/sym/ean8.rs
+++ b/src/sym/ean8.rs
@@ -1,13 +1,13 @@
 //! This module provides types for EAN-8 barcodes, which are EAN style barcodes for smaller
 //! packages on products like cigaretts, chewing gum, etc.
 
-use ::sym::Parse;
-use ::sym::EncodedBarcode;
-use ::sym::helpers;
-use ::sym::ean13::EAN_ENCODINGS;
-use ::sym::ean13::EAN_LEFT_GUARD;
-use ::sym::ean13::EAN_MIDDLE_GUARD;
-use ::sym::ean13::EAN_RIGHT_GUARD;
+use sym::Parse;
+use sym::EncodedBarcode;
+use sym::helpers;
+use sym::ean13::EAN_ENCODINGS;
+use sym::ean13::EAN_LEFT_GUARD;
+use sym::ean13::EAN_MIDDLE_GUARD;
+use sym::ean13::EAN_RIGHT_GUARD;
 use std::ops::Range;
 use std::char;
 
@@ -23,8 +23,10 @@ impl EAN8 {
     pub fn new(data: String) -> Result<EAN8, String> {
         match EAN8::parse(data) {
             Ok(d) => {
-                let digits = d.chars().map(|c| c.to_digit(10).expect("Unknown character") as u8).collect();
-                Ok(EAN8{data: digits})
+                let digits = d.chars()
+                              .map(|c| c.to_digit(10).expect("Unknown character") as u8)
+                              .collect();
+                Ok(EAN8 { data: digits })
             }
             Err(e) => Err(e),
         }
@@ -72,18 +74,18 @@ impl EAN8 {
 
     fn left_payload(&self) -> Vec<u8> {
         let slices: Vec<[u8; 7]> = self.left_digits()
-            .iter()
-            .map(|d| self.char_encoding(0, &d))
-            .collect();
+                                       .iter()
+                                       .map(|d| self.char_encoding(0, &d))
+                                       .collect();
 
         helpers::join_arrays(&slices[..])
     }
 
     fn right_payload(&self) -> Vec<u8> {
         let slices: Vec<[u8; 7]> = self.right_digits()
-            .iter()
-            .map(|d| self.char_encoding(2, &d))
-            .collect();
+                                       .iter()
+                                       .map(|d| self.char_encoding(2, &d))
+                                       .collect();
 
         helpers::join_arrays(&slices[..])
     }
@@ -91,14 +93,13 @@ impl EAN8 {
     /// Encodes the barcode.
     /// Returns a Vec<u8> of binary digits.
     pub fn encode(&self) -> EncodedBarcode {
-        helpers::join_slices(&[
-            &EAN_LEFT_GUARD[..],
-            &self.number_system_encoding()[..],
-            &self.left_payload()[..],
-            &EAN_MIDDLE_GUARD[..],
-            &self.right_payload()[..],
-            &self.checksum_encoding()[..],
-            &EAN_RIGHT_GUARD[..]][..])
+        helpers::join_slices(&[&EAN_LEFT_GUARD[..],
+                               &self.number_system_encoding()[..],
+                               &self.left_payload()[..],
+                               &EAN_MIDDLE_GUARD[..],
+                               &self.right_payload()[..],
+                               &self.checksum_encoding()[..],
+                               &EAN_RIGHT_GUARD[..]][..])
     }
 }
 
@@ -149,7 +150,7 @@ mod tests {
     fn ean8_raw_data() {
         let ean8 = EAN8::new("1234567".to_owned()).unwrap();
 
-        assert_eq!(ean8.raw_data(), &[1,2,3,4,5,6,7]);
+        assert_eq!(ean8.raw_data(), &[1, 2, 3, 4, 5, 6, 7]);
     }
 
     #[test]

--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -26,6 +26,7 @@ const EAN2_PARITY: [[usize; 5]; 4] = [
 ];
 
 /// The Supplemental EAN barcode type.
+#[derive(Debug)]
 pub enum EANSUPP {
     EAN2 {
         data: Vec<u8>,

--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -49,7 +49,7 @@ impl EANSUPP {
                 match digits.len() {
                     2 => Ok(EANSUPP::EAN2{data: digits}),
                     5 => Ok(EANSUPP::EAN5{data: digits}),
-                    n @ _ => Err(format!("Invalid supplemental length: {}", n)),
+                    n => Err(format!("Invalid supplemental length: {}", n)),
                 }
             }
             Err(e) => Err(e),
@@ -67,7 +67,7 @@ impl EANSUPP {
     fn char_encoding(&self, side: usize, d: &u8) -> [u8; 7] {
         EAN_ENCODINGS[side][*d as usize]
     }
- 
+
     /// Calculates the checksum digit using a modified modulo-10 weighting
     /// algorithm. This only makes sense for EAN5 barcodes.
     pub fn checksum_digit(&self) -> u8 {
@@ -83,8 +83,8 @@ impl EANSUPP {
         }
 
         match ((odds * 3) + (evens * 9)) % 10 {
-            10    => 0,
-            n @ _ => n,
+            10 => 0,
+            n  => n,
         }
     }
 

--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -2,14 +2,14 @@
 //! Supplemental EAN-2 barcodes are used in magazines and newspapers to indicate issue number and
 //! EAN-5 barcodes are often used to indicate the suggested retail price of books.
 
-use ::sym::Parse;
-use ::sym::EncodedBarcode;
-use ::sym::ean13::EAN_ENCODINGS;
-use ::sym::helpers;
+use sym::Parse;
+use sym::EncodedBarcode;
+use sym::ean13::EAN_ENCODINGS;
+use sym::helpers;
 use std::ops::Range;
 use std::char;
 
-const EANSUPP_LEFT_GUARD: [u8; 4] = [1,0,1,1];
+const EANSUPP_LEFT_GUARD: [u8; 4] = [1, 0, 1, 1];
 
 /// Maps parity (odd/even) for the EAN-5 barcodes based on the check digit.
 const EAN5_PARITY: [[usize; 5]; 10] = [
@@ -44,11 +44,13 @@ impl EANSUPP {
     pub fn new(data: String) -> Result<EANSUPP, String> {
         match EANSUPP::parse(data) {
             Ok(d) => {
-                let digits: Vec<u8> = d.chars().map(|c| c.to_digit(10).expect("Unknown character") as u8).collect();
+                let digits: Vec<u8> = d.chars()
+                                       .map(|c| c.to_digit(10).expect("Unknown character") as u8)
+                                       .collect();
 
                 match digits.len() {
-                    2 => Ok(EANSUPP::EAN2{data: digits}),
-                    5 => Ok(EANSUPP::EAN5{data: digits}),
+                    2 => Ok(EANSUPP::EAN2 { data: digits }),
+                    5 => Ok(EANSUPP::EAN5 { data: digits }),
                     n => Err(format!("Invalid supplemental length: {}", n)),
                 }
             }
@@ -77,14 +79,14 @@ impl EANSUPP {
 
         for (i, d) in data.iter().enumerate() {
             match i % 2 {
-                1 => { evens += *d }
-                _ => { odds += *d }
+                1 => evens += *d,
+                _ => odds += *d,
             }
         }
 
         match ((odds * 3) + (evens * 9)) % 10 {
             10 => 0,
-            n  => n,
+            n => n,
         }
     }
 
@@ -93,21 +95,21 @@ impl EANSUPP {
             EANSUPP::EAN2{data: ref d} => {
                 let modulo = ((d[0] * 10) + d[1]) % 4;
                 EAN2_PARITY[modulo as usize]
-            },
+            }
             EANSUPP::EAN5{data: ref _d} => {
                 let check = self.checksum_digit() as usize;
                 EAN5_PARITY[check]
-            },
+            }
         }
     }
 
     fn payload(&self) -> Vec<u8> {
         let mut p = vec![];
         let slices: Vec<[u8; 7]> = self.raw_data()
-            .iter()
-            .zip(self.parity().iter())
-            .map(|(d, s)| self.char_encoding(*s, &d))
-            .collect();
+                                       .iter()
+                                       .zip(self.parity().iter())
+                                       .map(|(d, s)| self.char_encoding(*s, &d))
+                                       .collect();
 
         for (i, d) in slices.iter().enumerate() {
             if i > 0 {
@@ -124,8 +126,7 @@ impl EANSUPP {
     /// Encodes the barcode.
     /// Returns a Vec<u8> of binary digits.
     pub fn encode(&self) -> EncodedBarcode {
-        helpers::join_slices(&[
-            &EANSUPP_LEFT_GUARD[..], &self.payload()[..]][..])
+        helpers::join_slices(&[&EANSUPP_LEFT_GUARD[..], &self.payload()[..]][..])
     }
 }
 
@@ -183,28 +184,30 @@ mod tests {
     fn ean2_raw_data() {
         let ean2 = EANSUPP::new("98".to_owned()).unwrap();
 
-        assert_eq!(ean2.raw_data(), &[9,8]);
+        assert_eq!(ean2.raw_data(), &[9, 8]);
     }
 
     #[test]
     fn ean5_raw_data() {
         let ean5 = EANSUPP::new("98567".to_owned()).unwrap();
 
-        assert_eq!(ean5.raw_data(), &[9,8,5,6,7]);
+        assert_eq!(ean5.raw_data(), &[9, 8, 5, 6, 7]);
     }
 
     #[test]
     fn ean2_encode() {
         let ean21 = EANSUPP::new("34".to_owned()).unwrap();
 
-        assert_eq!(collapse_vec(ean21.encode()), "10110100001010100011".to_owned());
+        assert_eq!(collapse_vec(ean21.encode()),
+                   "10110100001010100011".to_owned());
     }
 
     #[test]
     fn ean5_encode() {
         let ean51 = EANSUPP::new("51234".to_owned()).unwrap();
 
-        assert_eq!(collapse_vec(ean51.encode()), "10110110001010011001010011011010111101010011101".to_owned());
+        assert_eq!(collapse_vec(ean51.encode()),
+                   "10110110001010011001010011011010111101010011101".to_owned());
     }
 
 }

--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -153,58 +153,58 @@ mod tests {
 
     #[test]
     fn new_ean2() {
-        let ean2 = EANSUPP::new("12".to_string());
+        let ean2 = EANSUPP::new("12".to_owned());
 
         assert!(ean2.is_ok());
     }
 
     #[test]
     fn new_ean5() {
-        let ean5 = EANSUPP::new("12345".to_string());
+        let ean5 = EANSUPP::new("12345".to_owned());
 
         assert!(ean5.is_ok());
     }
 
     #[test]
     fn invalid_data_ean2() {
-        let ean2 = EANSUPP::new("AT".to_string());
+        let ean2 = EANSUPP::new("AT".to_owned());
 
         assert!(ean2.is_err());
     }
 
     #[test]
     fn invalid_len_ean2() {
-        let ean2 = EANSUPP::new("123".to_string());
+        let ean2 = EANSUPP::new("123".to_owned());
 
         assert!(ean2.is_err());
     }
 
     #[test]
     fn ean2_raw_data() {
-        let ean2 = EANSUPP::new("98".to_string()).unwrap();
+        let ean2 = EANSUPP::new("98".to_owned()).unwrap();
 
         assert_eq!(ean2.raw_data(), &[9,8]);
     }
 
     #[test]
     fn ean5_raw_data() {
-        let ean5 = EANSUPP::new("98567".to_string()).unwrap();
+        let ean5 = EANSUPP::new("98567".to_owned()).unwrap();
 
         assert_eq!(ean5.raw_data(), &[9,8,5,6,7]);
     }
 
     #[test]
     fn ean2_encode() {
-        let ean21 = EANSUPP::new("34".to_string()).unwrap();
+        let ean21 = EANSUPP::new("34".to_owned()).unwrap();
 
-        assert_eq!(collapse_vec(ean21.encode()), "10110100001010100011".to_string());
+        assert_eq!(collapse_vec(ean21.encode()), "10110100001010100011".to_owned());
     }
 
     #[test]
     fn ean5_encode() {
-        let ean51 = EANSUPP::new("51234".to_string()).unwrap();
+        let ean51 = EANSUPP::new("51234".to_owned()).unwrap();
 
-        assert_eq!(collapse_vec(ean51.encode()), "10110110001010011001010011011010111101010011101".to_string());
+        assert_eq!(collapse_vec(ean51.encode()), "10110110001010011001010011011010111101010011101".to_owned());
     }
 
 }

--- a/src/sym/helpers.rs
+++ b/src/sym/helpers.rs
@@ -1,9 +1,9 @@
 /// Joins and flattens the given slice of &[u8] slices into a Vec<u8>.
 pub fn join_slices(slices: &[&[u8]]) -> Vec<u8> {
     slices.iter()
-        .flat_map(|b| b.into_iter())
-        .cloned()
-        .collect()
+          .flat_map(|b| b.into_iter())
+          .cloned()
+          .collect()
 }
 
 /// Joins and flattens the given slice of &[u8] slices into a Vec<u8>.
@@ -32,17 +32,21 @@ pub fn modulo_10_checksum(data: &[u8], even_start: bool) -> u8 {
 
     for (i, d) in data.iter().enumerate() {
         match i % 2 {
-            1 => { odds += *d }
-            _ => { evens += *d }
+            1 => odds += *d,
+            _ => evens += *d,
         }
     }
 
     // EAN-13 (and some others?) barcodes use EVEN-first weighting to maintain
     // backwards compatibility.
-    if even_start { odds *= 3; } else { evens *= 3; }
+    if even_start {
+        odds *= 3;
+    } else {
+        evens *= 3;
+    }
 
     match 10 - ((odds + evens) % 10) {
         10 => 0,
-        n  => n,
+        n => n,
     }
 }

--- a/src/sym/helpers.rs
+++ b/src/sym/helpers.rs
@@ -42,7 +42,7 @@ pub fn modulo_10_checksum(data: &[u8], even_start: bool) -> u8 {
     if even_start { odds *= 3; } else { evens *= 3; }
 
     match 10 - ((odds + evens) % 10) {
-        10    => 0,
-        n @ _ => n,
+        10 => 0,
+        n  => n,
     }
 }

--- a/src/sym/mod.rs
+++ b/src/sym/mod.rs
@@ -1,7 +1,7 @@
 //! Supported barcode symbologies.
 //!
 //! Symbologies are separated into logical modules and thus you must `use` the appropriate one(s).
-//! 
+//!
 //! For example:
 //!
 //! ```rust
@@ -33,7 +33,9 @@ trait Parse {
         let data_len = data.len() as u32;
 
         if data_len < valid_len.start || data_len > valid_len.end {
-            return Err(format!("Data does not fit within range of {}-{}", valid_len.start, valid_len.end - 1));
+            return Err(format!("Data does not fit within range of {}-{}",
+                               valid_len.start,
+                               valid_len.end - 1));
         }
 
         let bad_char = data.chars().find(|&c| valid_chars.iter().find(|&vc| *vc == c).is_none());

--- a/src/sym/mod.rs
+++ b/src/sym/mod.rs
@@ -7,7 +7,7 @@
 //! ```rust
 //! use barcoders::sym::ean13::*;
 //!
-//! let barcode = EAN13::new("750103131130".to_string()).unwrap();
+//! let barcode = EAN13::new("750103131130".to_owned()).unwrap();
 //! let encoded = barcode.encode();
 //! ```
 

--- a/src/sym/tf.rs
+++ b/src/sym/tf.rs
@@ -22,6 +22,7 @@ const SFT_START: [u8; 8] = [1,1,0,1,1,0,1,0];
 const SFT_STOP: [u8; 8] = [1,1,0,1,0,1,1,0];
 
 /// The Interleaved 2-of-5 barcode type.
+#[derive(Debug)]
 pub enum TF {
     Standard {
         data: Vec<u8>,

--- a/src/sym/tf.rs
+++ b/src/sym/tf.rs
@@ -91,7 +91,7 @@ impl TF {
         let mut encoding: Vec<u8> = vec![];
 
         for (b, s) in bwidths.zip(swidths) {
-            for &(c, i) in [(b, 1), (s, 0)].iter() {
+            for &(c, i) in &[(b, 1), (s, 0)] {
                 match c {
                     'W' => encoding.extend([i; 3].iter().cloned()),
                     _ => encoding.push(i),

--- a/src/sym/tf.rs
+++ b/src/sym/tf.rs
@@ -3,9 +3,9 @@
 //! they also make an appearance in retail where they are sometimes used for the outer cartons on
 //! groups of products (cartons of Cola, etc).
 
-use ::sym::Parse;
-use ::sym::EncodedBarcode;
-use ::sym::helpers;
+use sym::Parse;
+use sym::EncodedBarcode;
+use sym::helpers;
 use std::ops::Range;
 use std::char;
 
@@ -16,10 +16,10 @@ const TF_WIDTHS: [&'static str; 10] = [
     "NWNWN",
 ];
 
-const IFT_START: [u8; 4] = [1,0,1,0];
-const IFT_STOP: [u8; 4] = [1,1,0,1];
-const SFT_START: [u8; 8] = [1,1,0,1,1,0,1,0];
-const SFT_STOP: [u8; 8] = [1,1,0,1,0,1,1,0];
+const IFT_START: [u8; 4] = [1, 0, 1, 0];
+const IFT_STOP: [u8; 4] = [1, 1, 0, 1];
+const SFT_START: [u8; 8] = [1, 1, 0, 1, 1, 0, 1, 0];
+const SFT_STOP: [u8; 8] = [1, 1, 0, 1, 0, 1, 1, 0];
 
 /// The Interleaved 2-of-5 barcode type.
 #[derive(Debug)]
@@ -41,7 +41,11 @@ impl TF {
     pub fn interleaved(data: String) -> Result<TF, String> {
         match TF::parse(data) {
             Ok(d) => {
-                let mut digits: Vec<u8> = d.chars().map(|c| c.to_digit(10).expect("Unknown character") as u8).collect();
+                let mut digits: Vec<u8> = d.chars()
+                                           .map(|c| {
+                                               c.to_digit(10).expect("Unknown character") as u8
+                                           })
+                                           .collect();
                 let checksum_required = digits.len() % 2 == 1;
 
                 if checksum_required {
@@ -49,7 +53,7 @@ impl TF {
                     digits.push(check_digit);
                 }
 
-                Ok(TF::Interleaved{data: digits})
+                Ok(TF::Interleaved { data: digits })
             }
             Err(e) => Err(e),
         }
@@ -61,8 +65,10 @@ impl TF {
     pub fn standard(data: String) -> Result<TF, String> {
         match TF::parse(data) {
             Ok(d) => {
-                let digits: Vec<u8> = d.chars().map(|c| c.to_digit(10).expect("Unknown character") as u8).collect();
-                Ok(TF::Standard{data: digits})
+                let digits: Vec<u8> = d.chars()
+                                       .map(|c| c.to_digit(10).expect("Unknown character") as u8)
+                                       .collect();
+                Ok(TF::Standard { data: digits })
             }
             Err(e) => Err(e),
         }
@@ -104,14 +110,14 @@ impl TF {
 
     fn char_encoding(&self, d: &u8) -> Vec<u8> {
         let bars: Vec<Vec<u8>> = self.char_widths(d)
-            .chars()
-            .map(|c| {
-                match c {
-                    'W' => vec![1,1,1,0],
-                    _ => vec![1,0],
-                }
-            })
-            .collect();
+                                     .chars()
+                                     .map(|c| {
+                                         match c {
+                                             'W' => vec![1, 1, 1, 0],
+                                             _ => vec![1, 0],
+                                         }
+                                     })
+                                     .collect();
 
         helpers::join_vecs(&bars[..])
     }
@@ -132,9 +138,9 @@ impl TF {
 
     fn itf_payload(&self) -> Vec<u8> {
         let weaves: Vec<Vec<u8>> = self.raw_data()
-            .chunks(2)
-            .map(|c| self.interleave(c[0], c[1]))
-            .collect();
+                                       .chunks(2)
+                                       .map(|c| self.interleave(c[0], c[1]))
+                                       .collect();
 
         helpers::join_vecs(&weaves[..])
     }
@@ -144,17 +150,11 @@ impl TF {
     pub fn encode(&self) -> EncodedBarcode {
         match *self {
             TF::Standard{data: _} => {
-                helpers::join_slices(
-                &[&SFT_START[..],
-                  &self.stf_payload()[..],
-                  &SFT_STOP[..]][..])
-            },
+                helpers::join_slices(&[&SFT_START[..], &self.stf_payload()[..], &SFT_STOP[..]][..])
+            }
             TF::Interleaved{data: _} => {
-                helpers::join_slices(
-                &[&IFT_START[..],
-                  &self.itf_payload()[..],
-                  &IFT_STOP[..]][..])
-            },
+                helpers::join_slices(&[&IFT_START[..], &self.itf_payload()[..], &IFT_STOP[..]][..])
+            }
         }
     }
 }
@@ -222,7 +222,7 @@ mod tests {
     fn itf_raw_data() {
         let itf = TF::interleaved("12345679".to_owned()).unwrap();
 
-        assert_eq!(itf.raw_data(), &[1,2,3,4,5,6,7,9]);
+        assert_eq!(itf.raw_data(), &[1, 2, 3, 4, 5, 6, 7, 9]);
     }
 
     #[test]

--- a/src/sym/tf.rs
+++ b/src/sym/tf.rs
@@ -184,21 +184,21 @@ mod tests {
 
     #[test]
     fn new_itf() {
-        let itf = TF::interleaved("12345679".to_string());
+        let itf = TF::interleaved("12345679".to_owned());
 
         assert!(itf.is_ok());
     }
 
     #[test]
     fn new_stf() {
-        let stf = TF::standard("12345".to_string());
+        let stf = TF::standard("12345".to_owned());
 
         assert!(stf.is_ok());
     }
 
     #[test]
     fn new_itf_with_checksum() {
-        let itf = TF::interleaved("1234567".to_string()).unwrap();
+        let itf = TF::interleaved("1234567".to_owned()).unwrap();
 
         assert!(itf.raw_data().len() % 2 == 0);
         assert_eq!(itf.checksum_digit(), Some(&0));
@@ -206,36 +206,36 @@ mod tests {
 
     #[test]
     fn invalid_data_itf() {
-        let itf = TF::interleaved("1234er123412".to_string());
+        let itf = TF::interleaved("1234er123412".to_owned());
 
         assert!(itf.is_err());
     }
 
     #[test]
     fn invalid_data_stf() {
-        let stf = TF::standard("WORDUP".to_string());
+        let stf = TF::standard("WORDUP".to_owned());
 
         assert!(stf.is_err());
     }
- 
+
     #[test]
     fn itf_raw_data() {
-        let itf = TF::interleaved("12345679".to_string()).unwrap();
+        let itf = TF::interleaved("12345679".to_owned()).unwrap();
 
         assert_eq!(itf.raw_data(), &[1,2,3,4,5,6,7,9]);
     }
 
     #[test]
     fn itf_encode() {
-        let itf = TF::interleaved("1234567".to_string()).unwrap(); // Check digit: 0
+        let itf = TF::interleaved("1234567".to_owned()).unwrap(); // Check digit: 0
 
-        assert_eq!(collapse_vec(itf.encode()), "10101110100010101110001110111010001010001110100011100010101010100011100011101101".to_string());
+        assert_eq!(collapse_vec(itf.encode()), "10101110100010101110001110111010001010001110100011100010101010100011100011101101".to_owned());
     }
 
     #[test]
     fn stf_encode() {
-        let stf = TF::standard("1234567".to_string()).unwrap();
+        let stf = TF::standard("1234567".to_owned()).unwrap();
 
-        assert_eq!(collapse_vec(stf.encode()), "110110101110101010111010111010101110111011101010101010111010111011101011101010101110111010101010101110111011010110".to_string());
+        assert_eq!(collapse_vec(stf.encode()), "110110101110101010111010111010101110111011101010101010111010111011101011101010101110111010101010101110111011010110".to_owned());
     }
 }


### PR DESCRIPTION
Along the lines of [this article](https://pascalhertleif.de/artikel/good-practices-for-writing-rust-libraries/), this
- enables more lints as warnings (especially missing-docs) and fixes some of the trivial things
- adds clippy lints (optional), and fixes warnings
- reformats the files with rustfmt (I chose not to include every change, e.g. for long lines or arrays)

This also adds a basic config for TravisCI. I you want to use it, you can easily generate and add a secret Github token to upload docs, and enable test coverage collection by re-enabling some of the commented lines.

Feel free to pick and choose which commits you want to merge.
