### PR TITLE
Remove unneeded calls to to_owned().

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ use barcoders::sym::ean13::*;
 
 // Each encoder accepts a String to be encoded. Valid data is barcode-specific
 // and thus constructors return an Result<T, barcoders::error::Error>.
-let barcode = EAN13::new("593456661897".to_owned()).unwrap();
+let barcode = EAN13::new("593456661897").unwrap();
 
 // The `encode` method returns a Vec<u8> of the binary representation of the
 // generated barcode. This is useful if you want to add your own generator.
@@ -97,7 +97,7 @@ use std::io::BufWriter;
 use std::fs::File;
 use std::path::Path;
 
-let barcode = Code39::new("1ISTHELONELIESTNUMBER".to_owned()).unwrap();
+let barcode = Code39::new("1ISTHELONELIESTNUMBER").unwrap();
 let png = Image::png(80); // You must specify the height in pixels.
 let encoded = barcode.encode();
 
@@ -115,7 +115,7 @@ writer.write(&bytes[..]).unwrap();
 
 You can also request an [image::RgbaImage](http://www.piston.rs/image/image/type.RgbaImage.html), which you can manipulate yourself:
 ```rust
-let barcode = Code39::new("BEELZEBUB".to_owned()).unwrap();
+let barcode = Code39::new("BEELZEBUB").unwrap();
 let buffer = Image::image_buffer(100);
 let encoded = barcode.encode();
 let img = buffer.generate_buffer(&encoded[..]).unwrap();
@@ -147,7 +147,7 @@ use std::io::BufWriter;
 use std::fs::File;
 use std::path::Path;
 
-let barcode = Code39::new("56DFU4A777H".to_owned()).unwrap();
+let barcode = Code39::new("56DFU4A777H").unwrap();
 let svg = SVG::new(200); // You must specify the height in pixels.
 let encoded = barcode.encode();
 let data: String = svg.generate(&encoded).unwrap();
@@ -176,7 +176,7 @@ extern crate barcoders;
 use barcoders::sym::ean13::*;
 use barcoders::generators::ascii::*;
 
-let barcode = EAN13::new("750103131130".to_owned()).unwrap();
+let barcode = EAN13::new("750103131130").unwrap();
 let encoded = barcode.encode();
 
 let ascii = ASCII::new();
@@ -194,7 +194,7 @@ assert_eq!(ascii.unwrap(),
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
-".trim().to_owned());
+".trim());
 ```
 
 
@@ -208,7 +208,7 @@ extern crate barcoders;
 use barcoders::sym::codabar::*;
 use barcoders::generators::json::*;
 
-let codabar = Codabar::new("A98B".to_owned()).unwrap();
+let codabar = Codabar::new("A98B").unwrap();
 let json = JSON::new();
 let generated = json.generate(&codabar.encode()[..]);
 

--- a/src/generators/ascii.rs
+++ b/src/generators/ascii.rs
@@ -68,7 +68,7 @@ mod tests {
 
     #[test]
     fn ean_13_as_ascii() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean13.encode()[..]).unwrap();
 
@@ -84,12 +84,12 @@ mod tests {
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
 # # ##   # #  ###  ##  # #  ### #### # ##  ## # # #    # ##  ## ##  ## #    # ###  # ### #  # #
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn ean_13_as_ascii_small_height_double_width() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let ascii = ASCII{height: 6, xdim: 2};
         let generated = ascii.generate(&ean13.encode()[..]).unwrap();
 
@@ -101,12 +101,12 @@ mod tests {
 ##  ##  ####      ##  ##    ######    ####    ##  ##    ######  ########  ##  ####    ####  ##  ##  ##        ##  ####    ####  ####    ####  ##        ##  ######    ##  ######  ##    ##  ##
 ##  ##  ####      ##  ##    ######    ####    ##  ##    ######  ########  ##  ####    ####  ##  ##  ##        ##  ####    ####  ####    ####  ##        ##  ######    ##  ######  ##    ##  ##
 ##  ##  ####      ##  ##    ######    ####    ##  ##    ######  ########  ##  ####    ####  ##  ##  ##        ##  ####    ####  ####    ####  ##        ##  ######    ##  ######  ##    ##  ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn ean_8_as_ascii() {
-        let ean8 = EAN8::new("1234567".to_owned()).unwrap();
+        let ean8 = EAN8::new("1234567").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean8.encode()[..]).unwrap();
 
@@ -122,12 +122,12 @@ mod tests {
 # #  ##  #  #  ## #### # #   ## # # #  ### # #    #   #  ###  # # #
 # #  ##  #  #  ## #### # #   ## # # #  ### # #    #   #  ###  # # #
 # #  ##  #  #  ## #### # #   ## # # #  ### # #    #   #  ###  # # #
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn ean_8_as_ascii_small_height_double_width() {
-        let ean8 = EAN8::new("1234567".to_owned()).unwrap();
+        let ean8 = EAN8::new("1234567").unwrap();
         let ascii = ASCII{height: 5, xdim: 2};
         let generated = ascii.generate(&ean8.encode()[..]).unwrap();
 
@@ -138,12 +138,12 @@ mod tests {
 ##  ##    ####    ##    ##    ####  ########  ##  ##      ####  ##  ##  ##    ######  ##  ##        ##      ##    ######    ##  ##  ##
 ##  ##    ####    ##    ##    ####  ########  ##  ##      ####  ##  ##  ##    ######  ##  ##        ##      ##    ######    ##  ##  ##
 ##  ##    ####    ##    ##    ####  ########  ##  ##      ####  ##  ##  ##    ######  ##  ##        ##      ##    ######    ##  ##  ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn code_39_as_ascii() {
-        let code39 = Code39::new("TEST8052".to_owned()).unwrap();
+        let code39 = Code39::new("TEST8052").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&code39.encode()[..]).unwrap();
 
@@ -159,12 +159,12 @@ mod tests {
 #  # ## ## # # # ## ##  # ## # ##  # # # ## # ##  # # # ## ##  # ## #  # ## # # #  ## ## # ## #  ## # # # ##  # # ## #  # ## ## #
 #  # ## ## # # # ## ##  # ## # ##  # # # ## # ##  # # # ## ##  # ## #  # ## # # #  ## ## # ## #  ## # # # ##  # # ## #  # ## ## #
 #  # ## ## # # # ## ##  # ## # ##  # # # ## # ##  # # # ## ##  # ## #  # ## # # #  ## ## # ## #  ## # # # ##  # # ## #  # ## ## #
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn code_39_as_ascii_small_height_double_weight() {
-        let code39 = Code39::new("1234".to_owned()).unwrap();
+        let code39 = Code39::new("1234").unwrap();
         let ascii = ASCII{height: 7, xdim: 2};
         let generated = ascii.generate(&code39.encode()[..]).unwrap();
 
@@ -177,12 +177,12 @@ mod tests {
 ##    ##  ####  ####  ##  ####  ##    ##  ##  ####  ##  ####    ##  ##  ####  ####  ####    ##  ##  ##  ##  ##    ####  ##  ####  ##    ##  ####  ####  ##
 ##    ##  ####  ####  ##  ####  ##    ##  ##  ####  ##  ####    ##  ##  ####  ####  ####    ##  ##  ##  ##  ##    ####  ##  ####  ##    ##  ####  ####  ##
 ##    ##  ####  ####  ##  ####  ##    ##  ##  ####  ##  ####    ##  ##  ####  ####  ####    ##  ##  ##  ##  ##    ####  ##  ####  ##    ##  ####  ####  ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn codabar_as_ascii() {
-        let codabar = Codabar::new("A98B".to_owned()).unwrap();
+        let codabar = Codabar::new("A98B").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&codabar.encode()[..]).unwrap();
 
@@ -198,12 +198,12 @@ mod tests {
 # ##  #  # ## #  # # #  ## # # # #  #  ##
 # ##  #  # ## #  # # #  ## # # # #  #  ##
 # ##  #  # ## #  # # #  ## # # # #  #  ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn codabar_as_ascii_small_height_double_weight() {
-        let codabar = Codabar::new("A40156B".to_owned()).unwrap();
+        let codabar = Codabar::new("A40156B").unwrap();
         let ascii = ASCII{height: 7, xdim: 2};
         let generated = ascii.generate(&codabar.encode()[..]).unwrap();
 
@@ -216,12 +216,12 @@ mod tests {
 ##  ####    ##    ##  ##  ####  ##    ##  ##  ##  ##    ####  ##  ##  ####    ##  ####  ##  ##    ##  ##    ##  ##  ####  ##  ##    ##    ####
 ##  ####    ##    ##  ##  ####  ##    ##  ##  ##  ##    ####  ##  ##  ####    ##  ####  ##  ##    ##  ##    ##  ##  ####  ##  ##    ##    ####
 ##  ####    ##    ##  ##  ####  ##    ##  ##  ##  ##    ####  ##  ##  ####    ##  ####  ##  ##    ##  ##    ##  ##  ####  ##  ##    ##    ####
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn code_128_as_ascii() {
-        let code128 = Code128::new("ÀHELLO".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHELLO").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&code128.encode()[..]).unwrap();
 
@@ -237,12 +237,12 @@ mod tests {
 ## #    #  ##   # #   #   ## #   #   ## ### #   ## ### #   ### ## ## #   #   ##   ### # ##
 ## #    #  ##   # #   #   ## #   #   ## ### #   ## ### #   ### ## ## #   #   ##   ### # ##
 ## #    #  ##   # #   #   ## #   #   ## ### #   ## ### #   ### ## ## #   #   ##   ### # ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn code_128_as_ascii_small_height_double_weight() {
-        let code128 = Code128::new("ÀHELLO".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHELLO").unwrap();
         let ascii = ASCII{height: 7, xdim: 2};
         let generated = ascii.generate(&code128.encode()[..]).unwrap();
 
@@ -255,12 +255,12 @@ mod tests {
 ####  ##        ##    ####      ##  ##      ##      ####  ##      ##      ####  ######  ##      ####  ######  ##      ######  ####  ####  ##      ##      ####      ######  ##  ####
 ####  ##        ##    ####      ##  ##      ##      ####  ##      ##      ####  ######  ##      ####  ######  ##      ######  ####  ####  ##      ##      ####      ######  ##  ####
 ####  ##        ##    ####      ##  ##      ##      ####  ##      ##      ####  ######  ##      ####  ######  ##      ######  ####  ####  ##      ##      ####      ######  ##  ####
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn ean2_as_ascii() {
-        let ean2 = EANSUPP::new("34".to_owned()).unwrap();
+        let ean2 = EANSUPP::new("34").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean2.encode()[..]).unwrap();
 
@@ -276,12 +276,12 @@ mod tests {
 # ## #    # # #   ##
 # ## #    # # #   ##
 # ## #    # # #   ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn ean5_as_ascii() {
-        let ean5 = EANSUPP::new("50799".to_owned()).unwrap();
+        let ean5 = EANSUPP::new("50799").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&ean5.encode()[..]).unwrap();
 
@@ -297,12 +297,12 @@ mod tests {
 # ## ##   # # #  ### #  #   # #   # ## #   # ##
 # ## ##   # # #  ### #  #   # #   # ## #   # ##
 # ## ##   # # #  ### #  #   # #   # ## #   # ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn itf_as_ascii() {
-        let itf = TF::interleaved("12345".to_owned()).unwrap();
+        let itf = TF::interleaved("12345").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&itf.encode()[..]).unwrap();
 
@@ -318,12 +318,12 @@ mod tests {
 # # ### #   # # ###   ### ### #   # #   ### # ### #   #   ## #
 # # ### #   # # ###   ### ### #   # #   ### # ### #   #   ## #
 # # ### #   # # ###   ### ### #   # #   ### # ### #   #   ## #
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn code_93_as_ascii() {
-        let code93 = Code93::new("TEST93".to_owned()).unwrap();
+        let code93 = Code93::new("TEST93").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&code93.encode()[..]).unwrap();
 
@@ -339,12 +339,12 @@ mod tests {
 # # #### ## #  ## ##  #  # ## # ##  ## #  ## #    # # # #    # # ### ## #  #   # # # #### #
 # # #### ## #  ## ##  #  # ## # ##  ## #  ## #    # # # #    # # ### ## #  #   # # # #### #
 # # #### ## #  ## ##  #  # ## # ##  ## #  ## #    # # # #    # # ### ## #  #   # # # #### #
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn code_93_as_ascii_small_height_double_weight() {
-        let code93 = Code93::new("TEST93".to_owned()).unwrap();
+        let code93 = Code93::new("TEST93").unwrap();
         let ascii = ASCII{height: 7, xdim: 2};
         let generated = ascii.generate(&code93.encode()[..]).unwrap();
 
@@ -357,12 +357,12 @@ mod tests {
 ##  ##  ########  ####  ##    ####  ####    ##    ##  ####  ##  ####    ####  ##    ####  ##        ##  ##  ##  ##        ##  ##  ######  ####  ##    ##      ##  ##  ##  ########  ##
 ##  ##  ########  ####  ##    ####  ####    ##    ##  ####  ##  ####    ####  ##    ####  ##        ##  ##  ##  ##        ##  ##  ######  ####  ##    ##      ##  ##  ##  ########  ##
 ##  ##  ########  ####  ##    ####  ####    ##    ##  ####  ##  ####    ####  ##    ####  ##        ##  ##  ##  ##        ##  ##  ######  ####  ##    ##      ##  ##  ##  ########  ##
-".trim().to_owned());
+".trim());
     }
 
     #[test]
     fn code_11_as_ascii() {
-        let code11 = Code11::new("12-9".to_owned()).unwrap();
+        let code11 = Code11::new("12-9").unwrap();
         let ascii = ASCII::new();
         let generated = ascii.generate(&code11.encode()[..]).unwrap();
 
@@ -378,6 +378,6 @@ mod tests {
 # ##  # ## # ## #  # ## # ## # ## # # #  ## # # ##  #
 # ##  # ## # ## #  # ## # ## # ## # # #  ## # # ##  #
 # ##  # ## # ## #  # ## # ## # ## # # #  ## # # ##  #
-".trim().to_owned());
+".trim());
     }
 }

--- a/src/generators/image.rs
+++ b/src/generators/image.rs
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn ean_13_as_gif() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let gif = Image::gif(80);
         let generated = gif.generate(&ean13.encode()[..]).unwrap();
 
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn ean_13_as_png() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let png = Image::PNG {
             height: 100,
             xdim: 1,
@@ -265,7 +265,7 @@ mod tests {
 
     #[test]
     fn rotated_ean_13_as_png() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let png = Image::PNG {
             height: 100,
             xdim: 1,
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn ean_13_as_jpeg() {
-        let ean13 = EAN13::new("999988881234".to_owned()).unwrap();
+        let ean13 = EAN13::new("999988881234").unwrap();
         let jpeg = Image::JPEG {
             height: 100,
             xdim: 3,
@@ -299,7 +299,7 @@ mod tests {
 
     #[test]
     fn ean_13_as_image_buffer() {
-        let ean13 = EAN13::new("7503995991130".to_owned()).unwrap();
+        let ean13 = EAN13::new("7503995991130").unwrap();
         let img = Image::ImageBuffer {
             height: 99,
             xdim: 1,
@@ -315,7 +315,7 @@ mod tests {
 
     #[test]
     fn colored_ean_13_as_gif() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let gif = Image::GIF {
             height: 99,
             xdim: 1,
@@ -333,7 +333,7 @@ mod tests {
 
     #[test]
     fn colored_semi_opaque_ean_13_as_png() {
-        let ean13 = EAN13::new("750153666132".to_owned()).unwrap();
+        let ean13 = EAN13::new("750153666132").unwrap();
         let png = Image::PNG {
             height: 99,
             xdim: 1,
@@ -351,7 +351,7 @@ mod tests {
 
     #[test]
     fn code39_as_png() {
-        let code39 = Code39::new("ILOVEMEL".to_owned()).unwrap();
+        let code39 = Code39::new("ILOVEMEL").unwrap();
         let png = Image::PNG {
             height: 60,
             xdim: 1,
@@ -368,7 +368,7 @@ mod tests {
 
     #[test]
     fn code39_as_gif() {
-        let code39 = Code39::new("WIKIPEDIA".to_owned()).unwrap();
+        let code39 = Code39::new("WIKIPEDIA").unwrap();
         let gif = Image::GIF {
             height: 60,
             xdim: 1,
@@ -385,7 +385,7 @@ mod tests {
 
     #[test]
     fn rotated_code39_as_gif() {
-        let code39 = Code39::new("HELLOWORLD".to_owned()).unwrap();
+        let code39 = Code39::new("HELLOWORLD").unwrap();
         let gif = Image::GIF {
             height: 60,
             xdim: 1,
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn code93_as_png() {
-        let code93 = Code93::new("ILOVEBAH".to_owned()).unwrap();
+        let code93 = Code93::new("ILOVEBAH").unwrap();
         let png = Image::PNG {
             height: 60,
             xdim: 1,
@@ -419,7 +419,7 @@ mod tests {
 
     #[test]
     fn code93_as_gif() {
-        let code93 = Code93::new("CIVIC VIDEO".to_owned()).unwrap();
+        let code93 = Code93::new("CIVIC VIDEO").unwrap();
         let gif = Image::GIF {
             height: 60,
             xdim: 1,
@@ -436,7 +436,7 @@ mod tests {
 
     #[test]
     fn rotated_code93_as_gif() {
-        let code93 = Code93::new("TWISTIES 100".to_owned()).unwrap();
+        let code93 = Code93::new("TWISTIES 100").unwrap();
         let gif = Image::GIF {
             height: 60,
             xdim: 1,
@@ -453,7 +453,7 @@ mod tests {
 
     #[test]
     fn code11_as_png() {
-        let code11 = Code11::new("9923-1111".to_owned()).unwrap();
+        let code11 = Code11::new("9923-1111").unwrap();
         let png = Image::PNG {
             height: 60,
             xdim: 1,
@@ -470,7 +470,7 @@ mod tests {
 
     #[test]
     fn code11_as_gif() {
-        let code11 = Code11::new("122333444455556666".to_owned()).unwrap();
+        let code11 = Code11::new("122333444455556666").unwrap();
         let gif = Image::GIF {
             height: 60,
             xdim: 1,
@@ -487,7 +487,7 @@ mod tests {
 
     #[test]
     fn codabar_as_png() {
-        let codabar = Codabar::new("B12354999A".to_owned()).unwrap();
+        let codabar = Codabar::new("B12354999A").unwrap();
         let png = Image::PNG {
             height: 60,
             xdim: 1,
@@ -504,7 +504,7 @@ mod tests {
 
     #[test]
     fn codabar_as_gif() {
-        let codabar = Codabar::new("A5675+++3$$B".to_owned()).unwrap();
+        let codabar = Codabar::new("A5675+++3$$B").unwrap();
         let gif = Image::GIF {
             height: 80,
             xdim: 2,
@@ -521,7 +521,7 @@ mod tests {
 
     #[test]
     fn rotated_codabar_as_gif() {
-        let codabar = Codabar::new("C1234D".to_owned()).unwrap();
+        let codabar = Codabar::new("C1234D").unwrap();
         let gif = Image::GIF {
             height: 60,
             xdim: 1,
@@ -538,7 +538,7 @@ mod tests {
 
     #[test]
     fn code128_as_png() {
-        let code128 = Code128::new("ÀHIĆ345678".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHIĆ345678").unwrap();
         let png = Image::PNG {
             height: 60,
             xdim: 1,
@@ -555,7 +555,7 @@ mod tests {
 
     #[test]
     fn code128_as_gif() {
-        let code128 = Code128::new("ÀHELLOWORLD".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHELLOWORLD").unwrap();
         let gif = Image::GIF {
             height: 90,
             xdim: 3,
@@ -572,7 +572,7 @@ mod tests {
 
     #[test]
     fn rotated_code128_as_gif() {
-        let code128 = Code128::new("ÀHELLOWORLD".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHELLOWORLD").unwrap();
         let gif = Image::GIF {
             height: 90,
             xdim: 3,
@@ -589,7 +589,7 @@ mod tests {
 
     #[test]
     fn rotated_code128_as_image_buffer() {
-        let code128 = Code128::new("ƁCLOJURE".to_owned()).unwrap();
+        let code128 = Code128::new("ƁCLOJURE").unwrap();
         let img = Image::ImageBuffer {
             height: 93,
             xdim: 2,
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn ean8_as_png() {
-        let ean8 = EAN8::new("5512345".to_owned()).unwrap();
+        let ean8 = EAN8::new("5512345").unwrap();
         let png = Image::PNG {
             height: 70,
             xdim: 2,
@@ -622,7 +622,7 @@ mod tests {
 
     #[test]
     fn rotated_ean8_as_png() {
-        let ean8 = EAN8::new("5512345".to_owned()).unwrap();
+        let ean8 = EAN8::new("5512345").unwrap();
         let png = Image::PNG {
             height: 70,
             xdim: 2,
@@ -639,7 +639,7 @@ mod tests {
 
     #[test]
     fn ean8_as_gif() {
-        let ean8 = EAN8::new("9992227".to_owned()).unwrap();
+        let ean8 = EAN8::new("9992227").unwrap();
         let gif = Image::GIF {
             height: 70,
             xdim: 2,
@@ -656,7 +656,7 @@ mod tests {
 
     #[test]
     fn ean8_as_jpeg() {
-        let ean8 = EAN8::new("9992227".to_owned()).unwrap();
+        let ean8 = EAN8::new("9992227").unwrap();
         let jpeg = Image::JPEG {
             height: 70,
             xdim: 2,
@@ -673,7 +673,7 @@ mod tests {
 
     #[test]
     fn ean2_as_png() {
-        let ean2 = EANSUPP::new("94".to_owned()).unwrap();
+        let ean2 = EANSUPP::new("94").unwrap();
         let png = Image::PNG {
             height: 70,
             xdim: 2,
@@ -690,7 +690,7 @@ mod tests {
 
     #[test]
     fn ean5_as_gif() {
-        let ean5 = EANSUPP::new("51234".to_owned()).unwrap();
+        let ean5 = EANSUPP::new("51234").unwrap();
         let gif = Image::GIF {
             height: 70,
             xdim: 2,
@@ -707,7 +707,7 @@ mod tests {
 
     #[test]
     fn ean5_as_jpeg() {
-        let ean5 = EANSUPP::new("51574".to_owned()).unwrap();
+        let ean5 = EANSUPP::new("51574").unwrap();
         let jpeg = Image::JPEG {
             height: 140,
             xdim: 5,
@@ -724,7 +724,7 @@ mod tests {
 
     #[test]
     fn ean5_as_imagebuffer() {
-        let ean5 = EANSUPP::new("99888".to_owned()).unwrap();
+        let ean5 = EANSUPP::new("99888").unwrap();
         let img = Image::ImageBuffer {
             height: 140,
             xdim: 1,
@@ -740,7 +740,7 @@ mod tests {
 
     #[test]
     fn itf_as_png() {
-        let itf = TF::interleaved("1234567".to_owned()).unwrap();
+        let itf = TF::interleaved("1234567").unwrap();
         let png = Image::PNG {
             height: 100,
             xdim: 2,
@@ -757,7 +757,7 @@ mod tests {
 
     #[test]
     fn stf_as_png() {
-        let stf = TF::standard("1234567".to_owned()).unwrap();
+        let stf = TF::standard("1234567").unwrap();
         let png = Image::PNG {
             height: 100,
             xdim: 2,
@@ -774,7 +774,7 @@ mod tests {
 
     #[test]
     fn itf_as_gif() {
-        let itf = TF::interleaved("98766543561".to_owned()).unwrap();
+        let itf = TF::interleaved("98766543561").unwrap();
         let gif = Image::GIF {
             height: 130,
             xdim: 1,
@@ -791,7 +791,7 @@ mod tests {
 
     #[test]
     fn itf_as_jpeg() {
-        let itf = TF::interleaved("98766543561".to_owned()).unwrap();
+        let itf = TF::interleaved("98766543561").unwrap();
         let jpeg = Image::JPEG {
             height: 130,
             xdim: 1,
@@ -808,7 +808,7 @@ mod tests {
 
     #[test]
     fn itf_as_imagebuffer() {
-        let itf = TF::interleaved("98766543561".to_owned()).unwrap();
+        let itf = TF::interleaved("98766543561").unwrap();
         let img = Image::ImageBuffer {
             height: 130,
             xdim: 1,
@@ -824,7 +824,7 @@ mod tests {
 
     #[test]
     fn image_buffer_fails_on_generate() {
-        let itf = TF::interleaved("98766543561".to_owned()).unwrap();
+        let itf = TF::interleaved("98766543561").unwrap();
         let img = Image::ImageBuffer {
             height: 130,
             xdim: 1,

--- a/src/generators/json.rs
+++ b/src/generators/json.rs
@@ -70,145 +70,145 @@ mod tests {
 
     #[test]
     fn ean_13_as_json() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let json = JSON::new();
         let generated = json.generate(&ean13.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,1,1,0,0,0,1,0,1,0,0,1,1,1,0,0,1,1,0,0,1,0,1,0,0,1,1,1,0,1,1,1,1,0,1,0,1,1,0,0,1,1,0,1,0,1,0,1,0,0,0,0,1,0,1,1,0,0,1,1,0,1,1,0,0,1,1,0,1,0,0,0,0,1,0,1,1,1,0,0,1,0,1,1,1,0,1,0,0,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,1,1,0,0,0,1,0,1,0,0,1,1,1,0,0,1,1,0,0,1,0,1,0,0,1,1,1,0,1,1,1,1,0,1,0,1,1,0,0,1,1,0,1,0,1,0,1,0,0,0,0,1,0,1,1,0,0,1,1,0,1,1,0,0,1,1,0,1,0,0,0,0,1,0,1,1,1,0,0,1,0,1,1,1,0,1,0,0,1,0,1]}".trim());
     }
 
     #[test]
     fn ean_13_as_json_small_height_double_width() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let json = JSON{height: 6, xdim: 2};
         let generated = json.generate(&ean13.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":6,\"xdim\":2,\"encoding\":[1,0,1,0,1,1,0,0,0,1,0,1,0,0,1,1,1,0,0,1,1,0,0,1,0,1,0,0,1,1,1,0,1,1,1,1,0,1,0,1,1,0,0,1,1,0,1,0,1,0,1,0,0,0,0,1,0,1,1,0,0,1,1,0,1,1,0,0,1,1,0,1,0,0,0,0,1,0,1,1,1,0,0,1,0,1,1,1,0,1,0,0,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":6,\"xdim\":2,\"encoding\":[1,0,1,0,1,1,0,0,0,1,0,1,0,0,1,1,1,0,0,1,1,0,0,1,0,1,0,0,1,1,1,0,1,1,1,1,0,1,0,1,1,0,0,1,1,0,1,0,1,0,1,0,0,0,0,1,0,1,1,0,0,1,1,0,1,1,0,0,1,1,0,1,0,0,0,0,1,0,1,1,1,0,0,1,0,1,1,1,0,1,0,0,1,0,1]}".trim());
     }
 
     #[test]
     fn ean_8_as_json() {
-        let ean8 = EAN8::new("1234567".to_owned()).unwrap();
+        let ean8 = EAN8::new("1234567").unwrap();
         let json = JSON::new();
         let generated = json.generate(&ean8.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,0,1,1,0,0,1,0,0,1,0,0,1,1,0,1,1,1,1,0,1,0,1,0,0,0,1,1,0,1,0,1,0,1,0,0,1,1,1,0,1,0,1,0,0,0,0,1,0,0,0,1,0,0,1,1,1,0,0,1,0,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,0,1,1,0,0,1,0,0,1,0,0,1,1,0,1,1,1,1,0,1,0,1,0,0,0,1,1,0,1,0,1,0,1,0,0,1,1,1,0,1,0,1,0,0,0,0,1,0,0,0,1,0,0,1,1,1,0,0,1,0,1,0,1]}".trim());
     }
 
     #[test]
     fn ean_8_as_json_small_height_double_width() {
-        let ean8 = EAN8::new("1234567".to_owned()).unwrap();
+        let ean8 = EAN8::new("1234567").unwrap();
         let json = JSON{height: 5, xdim: 2};
         let generated = json.generate(&ean8.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":5,\"xdim\":2,\"encoding\":[1,0,1,0,0,1,1,0,0,1,0,0,1,0,0,1,1,0,1,1,1,1,0,1,0,1,0,0,0,1,1,0,1,0,1,0,1,0,0,1,1,1,0,1,0,1,0,0,0,0,1,0,0,0,1,0,0,1,1,1,0,0,1,0,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":5,\"xdim\":2,\"encoding\":[1,0,1,0,0,1,1,0,0,1,0,0,1,0,0,1,1,0,1,1,1,1,0,1,0,1,0,0,0,1,1,0,1,0,1,0,1,0,0,1,1,1,0,1,0,1,0,0,0,0,1,0,0,0,1,0,0,1,1,1,0,0,1,0,1,0,1]}".trim());
     }
 
     #[test]
     fn code_93_as_json() {
-        let code93 = Code93::new("MONKEYMAGIC".to_owned()).unwrap();
+        let code93 = Code93::new("MONKEYMAGIC").unwrap();
         let json = JSON::new();
         let generated = json.generate(&code93.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,1,1,1,1,0,1,0,1,0,0,1,1,0,0,1,0,0,1,0,1,1,0,0,1,0,1,0,0,0,1,1,0,1,0,0,0,1,1,0,1,0,1,1,0,0,1,0,0,1,0,1,0,0,1,1,0,1,1,0,1,0,1,0,0,1,1,0,0,1,1,0,1,0,1,0,0,0,1,0,1,1,0,1,0,0,0,1,0,1,1,0,0,0,1,0,1,1,0,1,0,0,0,1,0,1,0,0,1,1,0,1,1,0,1,0,1,0,0,1,0,0,0,1,0,1,0,1,1,1,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,1,1,1,1,0,1,0,1,0,0,1,1,0,0,1,0,0,1,0,1,1,0,0,1,0,1,0,0,0,1,1,0,1,0,0,0,1,1,0,1,0,1,1,0,0,1,0,0,1,0,1,0,0,1,1,0,1,1,0,1,0,1,0,0,1,1,0,0,1,1,0,1,0,1,0,0,0,1,0,1,1,0,1,0,0,0,1,0,1,1,0,0,0,1,0,1,1,0,1,0,0,0,1,0,1,0,0,1,1,0,1,1,0,1,0,1,0,0,1,0,0,0,1,0,1,0,1,1,1,1,0,1]}".trim());
     }
 
     #[test]
     fn code_93_as_json_small_height_double_weight() {
-        let code93 = Code93::new("1234".to_owned()).unwrap();
+        let code93 = Code93::new("1234").unwrap();
         let json = JSON{height: 7, xdim: 2};
         let generated = json.generate(&code93.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,0,1,0,1,1,1,1,0,1,0,1,0,0,1,0,0,0,1,0,1,0,0,0,1,0,0,1,0,1,0,0,0,0,1,0,1,0,0,1,0,1,0,0,0,1,0,0,0,1,1,0,1,0,1,0,1,0,0,0,0,1,0,1,0,1,0,1,1,1,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,0,1,0,1,1,1,1,0,1,0,1,0,0,1,0,0,0,1,0,1,0,0,0,1,0,0,1,0,1,0,0,0,0,1,0,1,0,0,1,0,1,0,0,0,1,0,0,0,1,1,0,1,0,1,0,1,0,0,0,0,1,0,1,0,1,0,1,1,1,1,0,1]}".trim());
     }
 
     #[test]
     fn code_39_as_json() {
-        let code39 = Code39::new("TEST8052".to_owned()).unwrap();
+        let code39 = Code39::new("TEST8052").unwrap();
         let json = JSON::new();
         let generated = json.generate(&code39.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,0,1,0,1,1,0,1,1,0,1,0,1,0,1,0,1,1,0,1,1,0,0,1,0,1,1,0,1,0,1,1,0,0,1,0,1,0,1,0,1,1,0,1,0,1,1,0,0,1,0,1,0,1,0,1,1,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,1,0,1,0,1,0,0,1,1,0,1,1,0,1,0,1,1,0,1,0,0,1,1,0,1,0,1,0,1,0,1,1,0,0,1,0,1,0,1,1,0,1,0,0,1,0,1,1,0,1,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,0,1,0,1,1,0,1,1,0,1,0,1,0,1,0,1,1,0,1,1,0,0,1,0,1,1,0,1,0,1,1,0,0,1,0,1,0,1,0,1,1,0,1,0,1,1,0,0,1,0,1,0,1,0,1,1,0,1,1,0,0,1,0,1,1,0,1,0,0,1,0,1,1,0,1,0,1,0,1,0,0,1,1,0,1,1,0,1,0,1,1,0,1,0,0,1,1,0,1,0,1,0,1,0,1,1,0,0,1,0,1,0,1,1,0,1,0,0,1,0,1,1,0,1,1,0,1]}".trim());
     }
 
     #[test]
     fn code_39_as_json_small_height_double_weight() {
-        let code39 = Code39::new("1234".to_owned()).unwrap();
+        let code39 = Code39::new("1234").unwrap();
         let json = JSON{height: 7, xdim: 2};
         let generated = json.generate(&code39.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,0,0,1,0,1,1,0,1,1,0,1,0,1,1,0,1,0,0,1,0,1,0,1,1,0,1,0,1,1,0,0,1,0,1,0,1,1,0,1,1,0,1,1,0,0,1,0,1,0,1,0,1,0,1,0,0,1,1,0,1,0,1,1,0,1,0,0,1,0,1,1,0,1,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,0,0,1,0,1,1,0,1,1,0,1,0,1,1,0,1,0,0,1,0,1,0,1,1,0,1,0,1,1,0,0,1,0,1,0,1,1,0,1,1,0,1,1,0,0,1,0,1,0,1,0,1,0,1,0,0,1,1,0,1,0,1,1,0,1,0,0,1,0,1,1,0,1,1,0,1]}".trim());
     }
 
     #[test]
     fn codabar_as_json() {
-        let codabar = Codabar::new("A98B".to_owned()).unwrap();
+        let codabar = Codabar::new("A98B").unwrap();
         let json = JSON::new();
         let generated = json.generate(&codabar.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,0,1,0,0,1,0,1,1,0,1,0,0,1,0,1,0,1,0,0,1,1,0,1,0,1,0,1,0,1,0,0,1,0,0,1,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,0,1,0,0,1,0,1,1,0,1,0,0,1,0,1,0,1,0,0,1,1,0,1,0,1,0,1,0,1,0,0,1,0,0,1,1]}".trim());
     }
 
     #[test]
     fn codabar_as_json_small_height_double_weight() {
-        let codabar = Codabar::new("A40156B".to_owned()).unwrap();
+        let codabar = Codabar::new("A40156B").unwrap();
         let json = JSON{height: 7, xdim: 2};
         let generated = json.generate(&codabar.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,0,1,1,0,0,1,0,0,1,0,1,0,1,1,0,1,0,0,1,0,1,0,1,0,1,0,0,1,1,0,1,0,1,0,1,1,0,0,1,0,1,1,0,1,0,1,0,0,1,0,1,0,0,1,0,1,0,1,1,0,1,0,1,0,0,1,0,0,1,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,0,1,1,0,0,1,0,0,1,0,1,0,1,1,0,1,0,0,1,0,1,0,1,0,1,0,0,1,1,0,1,0,1,0,1,1,0,0,1,0,1,1,0,1,0,1,0,0,1,0,1,0,0,1,0,1,0,1,1,0,1,0,1,0,0,1,0,0,1,1]}".trim());
     }
 
     #[test]
     fn code_128_as_json() {
-        let code128 = Code128::new("ÀHELLO".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHELLO").unwrap();
         let json = JSON::new();
         let generated = json.generate(&code128.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,1,0,1,0,0,0,0,1,0,0,1,1,0,0,0,1,0,1,0,0,0,1,0,0,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,1,0,1,1,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,0,0,1,1,1,0,1,0,1,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,1,0,1,0,0,0,0,1,0,0,1,1,0,0,0,1,0,1,0,0,0,1,0,0,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,1,0,1,1,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,0,0,1,1,1,0,1,0,1,1]}".trim());
     }
 
     #[test]
     fn code_128_as_json_small_height_double_weight() {
-        let code128 = Code128::new("ÀHELLO".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHELLO").unwrap();
         let json = JSON{height: 7, xdim: 2};
         let generated = json.generate(&code128.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,1,0,1,0,0,0,0,1,0,0,1,1,0,0,0,1,0,1,0,0,0,1,0,0,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,1,0,1,1,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,0,0,1,1,1,0,1,0,1,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":7,\"xdim\":2,\"encoding\":[1,1,0,1,0,0,0,0,1,0,0,1,1,0,0,0,1,0,1,0,0,0,1,0,0,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,0,1,1,1,0,1,0,0,0,1,1,1,0,1,1,0,1,1,0,1,0,0,0,1,0,0,0,1,1,0,0,0,1,1,1,0,1,0,1,1]}".trim());
     }
 
     #[test]
     fn ean2_as_json() {
-        let ean2 = EANSUPP::new("34".to_owned()).unwrap();
+        let ean2 = EANSUPP::new("34").unwrap();
         let json = JSON::new();
         let generated = json.generate(&ean2.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,1,0,0,0,0,1,0,1,0,1,0,0,0,1,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,1,0,0,0,0,1,0,1,0,1,0,0,0,1,1]}".trim());
     }
 
     #[test]
     fn ean5_as_json() {
-        let ean5 = EANSUPP::new("50799".to_owned()).unwrap();
+        let ean5 = EANSUPP::new("50799").unwrap();
         let json = JSON::new();
         let generated = json.generate(&ean5.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,1,1,0,0,0,1,0,1,0,1,0,0,1,1,1,0,1,0,0,1,0,0,0,1,0,1,0,0,0,1,0,1,1,0,1,0,0,0,1,0,1,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,1,1,0,0,0,1,0,1,0,1,0,0,1,1,1,0,1,0,0,1,0,0,0,1,0,1,0,0,0,1,0,1,1,0,1,0,0,0,1,0,1,1]}".trim());
     }
 
     #[test]
     fn itf_as_json() {
-        let itf = TF::interleaved("12345".to_owned()).unwrap();
+        let itf = TF::interleaved("12345").unwrap();
         let json = JSON::new();
         let generated = json.generate(&itf.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,1,1,1,0,1,0,0,0,1,0,1,0,1,1,1,0,0,0,1,1,1,0,1,1,1,0,1,0,0,0,1,0,1,0,0,0,1,1,1,0,1,0,1,1,1,0,1,0,0,0,1,0,0,0,1,1,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,0,1,1,1,0,1,0,0,0,1,0,1,0,1,1,1,0,0,0,1,1,1,0,1,1,1,0,1,0,0,0,1,0,1,0,0,0,1,1,1,0,1,0,1,1,1,0,1,0,0,0,1,0,0,0,1,1,0,1]}".trim());
     }
 
     #[test]
     fn code11_as_json() {
-        let code11 = Code11::new("111-999-8".to_owned()).unwrap();
+        let code11 = Code11::new("111-999-8").unwrap();
         let json = JSON::new();
         let generated = json.generate(&code11.encode()[..]).unwrap();
 
-        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,0,1,0,1,1,0,1,0,1,1,0,1,1,0,1,0,1,1,0,1,1,0,1,0,1,1,0,1,0,1,1,0,1,0,1,1,0,1,0,1,0,1,1,0,1,0,1,0,1,1,0,1,0,1,0,1,0,1,1,0,1,0,1,1,0,1,0,0,1,0,1,0,1,0,1,1,0,1,0,1,1,0,0,1]}".trim().to_owned());
+        assert_eq!(generated, "{\"height\":10,\"xdim\":1,\"encoding\":[1,0,1,1,0,0,1,0,1,1,0,1,0,1,1,0,1,1,0,1,0,1,1,0,1,1,0,1,0,1,1,0,1,0,1,1,0,1,0,1,1,0,1,0,1,0,1,1,0,1,0,1,0,1,1,0,1,0,1,0,1,0,1,1,0,1,0,1,1,0,1,0,0,1,0,1,0,1,0,1,1,0,1,0,1,1,0,0,1]}".trim());
     }
 }

--- a/src/generators/svg.rs
+++ b/src/generators/svg.rs
@@ -164,7 +164,7 @@ mod tests {
 
     #[test]
     fn ean_13_as_svg() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let svg = SVG::new(80);
         let generated = svg.generate(&ean13.encode()[..]).unwrap();
 
@@ -175,7 +175,7 @@ mod tests {
 
     #[test]
     fn colored_ean_13_as_svg() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let svg = SVG{height: 80,
                       xdim: 1,
                       background: Color{rgba: [255, 0, 0, 255]},
@@ -189,7 +189,7 @@ mod tests {
 
     #[test]
     fn colored_semi_transparent_ean_13_as_svg() {
-        let ean13 = EAN13::new("750103131130".to_owned()).unwrap();
+        let ean13 = EAN13::new("750103131130").unwrap();
         let svg = SVG{height: 70,
                       xdim: 1,
                       background: Color{rgba: [255, 0, 0, 128]},
@@ -204,7 +204,7 @@ mod tests {
 
     #[test]
     fn ean_8_as_svg() {
-        let ean8 = EAN8::new("9998823".to_owned()).unwrap();
+        let ean8 = EAN8::new("9998823").unwrap();
         let svg = SVG::new(80);
         let generated = svg.generate(&ean8.encode()[..]).unwrap();
 
@@ -215,7 +215,7 @@ mod tests {
 
     #[test]
     fn code39_as_svg() {
-        let code39 = Code39::new("IGOT99PROBLEMS".to_owned()).unwrap();
+        let code39 = Code39::new("IGOT99PROBLEMS").unwrap();
         let svg = SVG::new(80);
         let generated = svg.generate(&code39.encode()[..]).unwrap();
 
@@ -226,7 +226,7 @@ mod tests {
 
     #[test]
     fn code93_as_svg() {
-        let code93 = Code93::new("IGOT99PROBLEMS".to_owned()).unwrap();
+        let code93 = Code93::new("IGOT99PROBLEMS").unwrap();
         let svg = SVG::new(80);
         let generated = svg.generate(&code93.encode()[..]).unwrap();
 
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn codabar_as_svg() {
-        let codabar = Codabar::new("A12----34A".to_owned()).unwrap();
+        let codabar = Codabar::new("A12----34A").unwrap();
         let svg = SVG::new(80);
         let generated = svg.generate(&codabar.encode()[..]).unwrap();
 
@@ -248,7 +248,7 @@ mod tests {
 
     #[test]
     fn code128_as_svg() {
-        let code128 = Code128::new("ÀHIĆ345678".to_owned()).unwrap();
+        let code128 = Code128::new("ÀHIĆ345678").unwrap();
         let svg = SVG::new(80);
         let generated = svg.generate(&code128.encode()[..]).unwrap();
 
@@ -259,7 +259,7 @@ mod tests {
 
     #[test]
     fn ean_2_as_svg() {
-        let ean2 = EANSUPP::new("78".to_owned()).unwrap();
+        let ean2 = EANSUPP::new("78").unwrap();
         let svg = SVG::new(80);
         let generated = svg.generate(&ean2.encode()[..]).unwrap();
 
@@ -270,7 +270,7 @@ mod tests {
 
     #[test]
     fn itf_as_svg() {
-        let itf = TF::interleaved("1234123488993344556677118".to_owned()).unwrap();
+        let itf = TF::interleaved("1234123488993344556677118").unwrap();
         let svg = SVG{height: 80,
                       xdim: 1,
                       background: Color::black(),
@@ -284,7 +284,7 @@ mod tests {
 
     #[test]
     fn code11_as_svg() {
-        let code11 = Code11::new("9988-45643201".to_owned()).unwrap();
+        let code11 = Code11::new("9988-45643201").unwrap();
         let svg = SVG{height: 80,
                       xdim: 1,
                       background: Color::black(),

--- a/src/sym/codabar.rs
+++ b/src/sym/codabar.rs
@@ -137,24 +137,24 @@ mod tests {
 
     #[test]
     fn invalid_length_codabar() {
-        let codabar = Codabar::new("".to_owned());
+        let codabar = Codabar::new("");
 
         assert_eq!(codabar.err().unwrap(), Error::Length);
     }
 
     #[test]
     fn invalid_data_codabar() {
-        let codabar = Codabar::new("A12345G".to_owned());
+        let codabar = Codabar::new("A12345G");
 
         assert_eq!(codabar.err().unwrap(), Error::Character);
     }
 
     #[test]
     fn codabar_encode() {
-        let codabar_a = Codabar::new("A1234B".to_owned()).unwrap();
-        let codabar_b = Codabar::new("A40156B".to_owned()).unwrap();
+        let codabar_a = Codabar::new("A1234B").unwrap();
+        let codabar_b = Codabar::new("A40156B").unwrap();
  
-        assert_eq!(collapse_vec(codabar_a.encode()), "1011001001010101100101010010110110010101010110100101010010011".to_owned());
-        assert_eq!(collapse_vec(codabar_b.encode()), "10110010010101101001010101001101010110010110101001010010101101010010011".to_owned());
+        assert_eq!(collapse_vec(codabar_a.encode()), "1011001001010101100101010010110110010101010110100101010010011");
+        assert_eq!(collapse_vec(codabar_b.encode()), "10110010010101101001010101001101010110010110101001010010101101010010011");
     }
 }

--- a/src/sym/code11.rs
+++ b/src/sym/code11.rs
@@ -148,33 +148,33 @@ mod tests {
 
     #[test]
     fn invalid_length_code11() {
-        let code11 = Code11::new("".to_owned());
+        let code11 = Code11::new("");
 
         assert_eq!(code11.err().unwrap(), Error::Length);
     }
 
     #[test]
     fn invalid_data_code11() {
-        let code11 = Code11::new("NOTDIGITS".to_owned());
+        let code11 = Code11::new("NOTDIGITS");
 
         assert_eq!(code11.err().unwrap(), Error::Character);
     }
 
     #[test]
     fn code11_encode_less_than_10_chars() {
-        let code111 = Code11::new("123-45".to_owned()).unwrap();
-        let code112 = Code11::new("666".to_owned()).unwrap();
-        let code113 = Code11::new("12-9".to_owned()).unwrap();
+        let code111 = Code11::new("123-45").unwrap();
+        let code112 = Code11::new("666").unwrap();
+        let code113 = Code11::new("12-9").unwrap();
 
-        assert_eq!(collapse_vec(code111.encode()), "1011001011010110100101101100101010110101011011011011010110110101011001".to_owned());
-        assert_eq!(collapse_vec(code112.encode()), "10110010100110101001101010011010110010101011001".to_owned());
-        assert_eq!(collapse_vec(code113.encode()), "10110010110101101001011010110101101010100110101011001".to_owned());
+        assert_eq!(collapse_vec(code111.encode()), "1011001011010110100101101100101010110101011011011011010110110101011001");
+        assert_eq!(collapse_vec(code112.encode()), "10110010100110101001101010011010110010101011001");
+        assert_eq!(collapse_vec(code113.encode()), "10110010110101101001011010110101101010100110101011001");
     }
 
     #[test]
     fn code11_encode_more_than_10_chars() {
-        let code111 = Code11::new("1234-5678-4321".to_owned()).unwrap();
+        let code111 = Code11::new("1234-5678-4321").unwrap();
 
-        assert_eq!(collapse_vec(code111.encode()), "101100101101011010010110110010101011011010110101101101010011010101001101101001010110101011011011001010100101101101011011011010100110101011001".to_owned());
+        assert_eq!(collapse_vec(code111.encode()), "101100101101011010010110110010101011011010110101101101010011010101001101101001010110101011011011001010100101101101011011011010100110101011001");
     }
 }

--- a/src/sym/code128.rs
+++ b/src/sym/code128.rs
@@ -304,8 +304,8 @@ mod tests {
 
     #[test]
     fn new_code128() {
-        let code128_a = Code128::new("À !! Ć0201".to_owned());
-        let code128_b = Code128::new("À!!  \" ".to_owned());
+        let code128_a = Code128::new("À !! Ć0201");
+        let code128_b = Code128::new("À!!  \" ");
 
         assert!(code128_a.is_ok());
         assert!(code128_b.is_ok());
@@ -313,16 +313,16 @@ mod tests {
 
     #[test]
     fn invalid_length_code128() {
-        let code128_a = Code128::new("".to_owned());
+        let code128_a = Code128::new("");
 
         assert_eq!(code128_a.err().unwrap(), Error::Length);
     }
 
     #[test]
     fn invalid_data_code128() {
-        let code128_a = Code128::new("À☺ ".to_owned()); // Unknown character.
-        let code128_b = Code128::new("ÀHELLOĆ12352".to_owned()); // Trailing carry at the end.
-        let code128_c = Code128::new("HELLO".to_owned()); // No Character-Set specified.
+        let code128_a = Code128::new("À☺ "); // Unknown character.
+        let code128_b = Code128::new("ÀHELLOĆ12352"); // Trailing carry at the end.
+        let code128_c = Code128::new("HELLO"); // No Character-Set specified.
 
         assert_eq!(code128_a.err().unwrap(), Error::Character);
         assert_eq!(code128_b.err().unwrap(), Error::Character);
@@ -331,37 +331,37 @@ mod tests {
 
     #[test]
     fn code128_encode() {
-        let code128_a = Code128::new("ÀHELLO".to_owned()).unwrap();
-        let code128_b = Code128::new("ÀXYĆ2199".to_owned()).unwrap();
-        let code128_c = Code128::new("ƁxyZÀ199!*1".to_owned()).unwrap();
+        let code128_a = Code128::new("ÀHELLO").unwrap();
+        let code128_b = Code128::new("ÀXYĆ2199").unwrap();
+        let code128_c = Code128::new("ƁxyZÀ199!*1").unwrap();
 
-        assert_eq!(collapse_vec(code128_a.encode()), "110100001001100010100010001101000100011011101000110111010001110110110100010001100011101011".to_owned());
-        assert_eq!(collapse_vec(code128_b.encode()), "110100001001110001011011101101000101110111101101110010010111011110100111011001100011101011".to_owned());
-        assert_eq!(collapse_vec(code128_c.encode()), "1101001000011110010010110110111101110110001011101011110100111001101110010110011100101100110011011001100100010010011100110100101111001100011101011".to_owned());
+        assert_eq!(collapse_vec(code128_a.encode()), "110100001001100010100010001101000100011011101000110111010001110110110100010001100011101011");
+        assert_eq!(collapse_vec(code128_b.encode()), "110100001001110001011011101101000101110111101101110010010111011110100111011001100011101011");
+        assert_eq!(collapse_vec(code128_c.encode()), "1101001000011110010010110110111101110110001011101011110100111001101110010110011100101100110011011001100100010010011100110100101111001100011101011");
     }
 
     #[test]
     fn code128_encode_special_chars() {
-        let code128_a = Code128::new("ÀB\u{0006}".to_owned()).unwrap();
+        let code128_a = Code128::new("ÀB\u{0006}").unwrap();
 
-        assert_eq!(collapse_vec(code128_a.encode()), "110100001001000101100010110000100100110100001100011101011".to_owned());
+        assert_eq!(collapse_vec(code128_a.encode()), "110100001001000101100010110000100100110100001100011101011");
     }
  
     #[test]
     fn code128_encode_fnc_chars() {
-        let code128_a = Code128::new("ĆŹ4218402050À0".to_owned()).unwrap();
+        let code128_a = Code128::new("ĆŹ4218402050À0").unwrap();
 
-        assert_eq!(collapse_vec(code128_a.encode()), "110100111001111010111010110111000110011100101100010100011001001110110001011101110101111010011101100111101101101100011101011".to_owned());
+        assert_eq!(collapse_vec(code128_a.encode()), "110100111001111010111010110111000110011100101100010100011001001110110001011101110101111010011101100111101101101100011101011");
     }
  
     #[test]
     fn code128_encode_longhand() {
-        let code128_a = Code128::new("\u{00C0}HELLO".to_owned()).unwrap();
-        let code128_b = Code128::new("\u{00C0}XY\u{0106}2199".to_owned()).unwrap();
-        let code128_c = Code128::new("\u{0181}xyZ\u{00C0}199!*1".to_owned()).unwrap();
+        let code128_a = Code128::new("\u{00C0}HELLO").unwrap();
+        let code128_b = Code128::new("\u{00C0}XY\u{0106}2199").unwrap();
+        let code128_c = Code128::new("\u{0181}xyZ\u{00C0}199!*1").unwrap();
 
-        assert_eq!(collapse_vec(code128_a.encode()), "110100001001100010100010001101000100011011101000110111010001110110110100010001100011101011".to_owned());
-        assert_eq!(collapse_vec(code128_b.encode()), "110100001001110001011011101101000101110111101101110010010111011110100111011001100011101011".to_owned());
-        assert_eq!(collapse_vec(code128_c.encode()), "1101001000011110010010110110111101110110001011101011110100111001101110010110011100101100110011011001100100010010011100110100101111001100011101011".to_owned());
+        assert_eq!(collapse_vec(code128_a.encode()), "110100001001100010100010001101000100011011101000110111010001110110110100010001100011101011");
+        assert_eq!(collapse_vec(code128_b.encode()), "110100001001110001011011101101000101110111101101110010010111011110100111011001100011101011");
+        assert_eq!(collapse_vec(code128_c.encode()), "1101001000011110010010110110111101110110001011101011110100111001101110010110011100101100110011011001100100010010011100110100101111001100011101011");
     }
 }

--- a/src/sym/code39.rs
+++ b/src/sym/code39.rs
@@ -142,42 +142,42 @@ mod tests {
 
     #[test]
     fn new_code39() {
-        let code39 = Code39::new("12345".to_owned());
+        let code39 = Code39::new("12345");
 
         assert!(code39.is_ok());
     }
 
     #[test]
     fn invalid_data_code39() {
-        let code39 = Code39::new("1212s".to_owned());
+        let code39 = Code39::new("1212s");
 
         assert_eq!(code39.err().unwrap(), Error::Character);
     }
 
     #[test]
     fn invalid_len_code39() {
-        let code39 = Code39::new("".to_owned());
+        let code39 = Code39::new("");
 
         assert_eq!(code39.err().unwrap(), Error::Length);
     }
 
     #[test]
     fn code39_encode() {
-        let code391 = Code39::new("1234".to_owned()).unwrap();
-        let code392 = Code39::new("983RD512".to_owned()).unwrap();
-        let code393 = Code39::new("TEST8052".to_owned()).unwrap();
+        let code391 = Code39::new("1234").unwrap();
+        let code392 = Code39::new("983RD512").unwrap();
+        let code393 = Code39::new("TEST8052").unwrap();
 
-        assert_eq!(collapse_vec(code391.encode()), "10010110110101101001010110101100101011011011001010101010011010110100101101101".to_owned());
-        assert_eq!(collapse_vec(code392.encode()), "100101101101010110010110101101001011010110110010101011010101100101010110010110110100110101011010010101101011001010110100101101101".to_owned());
-        assert_eq!(collapse_vec(code393.encode()), "100101101101010101101100101101011001010101101011001010101101100101101001011010101001101101011010011010101011001010110100101101101".to_owned());
+        assert_eq!(collapse_vec(code391.encode()), "10010110110101101001010110101100101011011011001010101010011010110100101101101");
+        assert_eq!(collapse_vec(code392.encode()), "100101101101010110010110101101001011010110110010101011010101100101010110010110110100110101011010010101101011001010110100101101101");
+        assert_eq!(collapse_vec(code393.encode()), "100101101101010101101100101101011001010101101011001010101101100101101001011010101001101101011010011010101011001010110100101101101");
     }
 
     #[test]
     fn code39_encode_with_checksum() {
-        let code391 = Code39::with_checksum("1234".to_owned()).unwrap();
-        let code392 = Code39::with_checksum("983RD512".to_owned()).unwrap();
+        let code391 = Code39::with_checksum("1234").unwrap();
+        let code392 = Code39::with_checksum("983RD512").unwrap();
 
-        assert_eq!(collapse_vec(code391.encode()), "100101101101011010010101101011001010110110110010101010100110101101101010010110100101101101".to_owned());
-        assert_eq!(collapse_vec(code392.encode()), "1001011011010101100101101011010010110101101100101010110101011001010101100101101101001101010110100101011010110010101101011011010010100101101101".to_owned());
+        assert_eq!(collapse_vec(code391.encode()), "100101101101011010010101101011001010110110110010101010100110101101101010010110100101101101");
+        assert_eq!(collapse_vec(code392.encode()), "1001011011010101100101101011010010110101101100101010110101011001010101100101101101001101010110100101011010110010101101011011010010100101101101");
     }
 }

--- a/src/sym/code93.rs
+++ b/src/sym/code93.rs
@@ -149,14 +149,14 @@ mod tests {
 
     #[test]
     fn invalid_length_code93() {
-        let code93 = Code93::new("".to_owned());
+        let code93 = Code93::new("");
 
         assert_eq!(code93.err().unwrap(), Error::Length);
     }
 
     #[test]
     fn invalid_data_code93() {
-        let code93 = Code93::new("lowerCASE".to_owned());
+        let code93 = Code93::new("lowerCASE");
 
         assert_eq!(code93.err().unwrap(), Error::Character);
     }
@@ -164,14 +164,14 @@ mod tests {
     #[test]
     fn code93_encode() {
         // Tests for data longer than 15, data longer than 20
-        let code931 = Code93::new("TEST93".to_owned()).unwrap();
-        let code932 = Code93::new("FLAM".to_owned()).unwrap();
-        let code933 = Code93::new("99".to_owned()).unwrap();
-        let code934 = Code93::new("1111111111111111111111".to_owned()).unwrap();
+        let code931 = Code93::new("TEST93").unwrap();
+        let code932 = Code93::new("FLAM").unwrap();
+        let code933 = Code93::new("99").unwrap();
+        let code934 = Code93::new("1111111111111111111111").unwrap();
 
-        assert_eq!(collapse_vec(code931.encode()), "1010111101101001101100100101101011001101001101000010101010000101011101101001000101010111101".to_owned());
-        assert_eq!(collapse_vec(code932.encode()), "1010111101100010101010110001101010001010011001001011001010011001010111101".to_owned());
-        assert_eq!(collapse_vec(code933.encode()), "1010111101000010101000010101101100101000101101010111101".to_owned());
-        assert_eq!(collapse_vec(code934.encode()), "1010111101010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001000101101110010101010111101".to_owned());
+        assert_eq!(collapse_vec(code931.encode()), "1010111101101001101100100101101011001101001101000010101010000101011101101001000101010111101");
+        assert_eq!(collapse_vec(code932.encode()), "1010111101100010101010110001101010001010011001001011001010011001010111101");
+        assert_eq!(collapse_vec(code933.encode()), "1010111101000010101000010101101100101000101101010111101");
+        assert_eq!(collapse_vec(code934.encode()), "1010111101010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001010010001000101101110010101010111101");
     }
 }

--- a/src/sym/ean13.rs
+++ b/src/sym/ean13.rs
@@ -164,56 +164,56 @@ mod tests {
 
     #[test]
     fn new_ean13() {
-        let ean13 = EAN13::new("123456123456".to_owned());
+        let ean13 = EAN13::new("123456123456");
 
         assert!(ean13.is_ok());
     }
 
     #[test]
     fn new_bookland() {
-        let bookland = Bookland::new("978456123456".to_owned());
+        let bookland = Bookland::new("978456123456");
 
         assert!(bookland.is_ok());
     }
 
     #[test]
     fn invalid_data_ean13() {
-        let ean13 = EAN13::new("1234er123412".to_owned());
+        let ean13 = EAN13::new("1234er123412");
 
         assert_eq!(ean13.err().unwrap(), Error::Character)
     }
 
     #[test]
     fn invalid_len_ean13() {
-        let ean13 = EAN13::new("1111112222222333333".to_owned());
+        let ean13 = EAN13::new("1111112222222333333");
 
         assert_eq!(ean13.err().unwrap(), Error::Length)
     }
 
     #[test]
     fn ean13_encode_as_upca() {
-        let ean131 = UPCA::new("012345612345".to_owned()).unwrap(); // Check digit: 8
-        let ean132 = UPCA::new("000118999561".to_owned()).unwrap(); // Check digit: 3
+        let ean131 = UPCA::new("012345612345").unwrap(); // Check digit: 8
+        let ean132 = UPCA::new("000118999561").unwrap(); // Check digit: 3
 
-        assert_eq!(collapse_vec(ean131.encode()), "10100110010010011011110101000110110001010111101010110011011011001000010101110010011101001000101".to_owned());
-        assert_eq!(collapse_vec(ean132.encode()), "10100011010001101001100100110010110111000101101010111010011101001001110101000011001101000010101".to_owned());
+        assert_eq!(collapse_vec(ean131.encode()), "10100110010010011011110101000110110001010111101010110011011011001000010101110010011101001000101");
+        assert_eq!(collapse_vec(ean132.encode()), "10100011010001101001100100110010110111000101101010111010011101001001110101000011001101000010101");
     }
 
     #[test]
     fn ean13_encode_as_bookland() {
-        let bookland1 = Bookland::new("978345612345".to_owned()).unwrap(); // Check digit: 5
-        let bookland2 = Bookland::new("978118999561".to_owned()).unwrap(); // Check digit: 5
+        let bookland1 = Bookland::new("978345612345").unwrap(); // Check digit: 5
+        let bookland2 = Bookland::new("978118999561").unwrap(); // Check digit: 5
 
-        assert_eq!(collapse_vec(bookland1.encode()), "10101110110001001010000101000110111001010111101010110011011011001000010101110010011101001110101".to_owned());
-        assert_eq!(collapse_vec(bookland2.encode()), "10101110110001001011001100110010001001000101101010111010011101001001110101000011001101001110101".to_owned());
+        assert_eq!(collapse_vec(bookland1.encode()), "10101110110001001010000101000110111001010111101010110011011011001000010101110010011101001110101");
+        assert_eq!(collapse_vec(bookland2.encode()), "10101110110001001011001100110010001001000101101010111010011101001001110101000011001101001110101");
     }
 
     #[test]
     fn ean13_encode() {
-        let ean131 = EAN13::new("750103131130".to_owned()).unwrap(); // Check digit: 5
-        let ean132 = EAN13::new("983465123499".to_owned()).unwrap(); // Check digit: 5
+        let ean131 = EAN13::new("750103131130").unwrap(); // Check digit: 5
+        let ean132 = EAN13::new("983465123499").unwrap(); // Check digit: 5
 
-        assert_eq!(collapse_vec(ean131.encode()), "10101100010100111001100101001110111101011001101010100001011001101100110100001011100101110100101".to_owned());
-        assert_eq!(collapse_vec(ean132.encode()), "10101101110100001001110101011110111001001100101010110110010000101011100111010011101001000010101".to_owned());
+        assert_eq!(collapse_vec(ean131.encode()), "10101100010100111001100101001110111101011001101010100001011001101100110100001011100101110100101");
+        assert_eq!(collapse_vec(ean132.encode()), "10101101110100001001110101011110111001001100101010110110010000101011100111010011101001000010101");
     }
 }

--- a/src/sym/ean8.rs
+++ b/src/sym/ean8.rs
@@ -119,31 +119,31 @@ mod tests {
 
     #[test]
     fn new_ean8() {
-        let ean8 = EAN8::new("1234567".to_owned());
+        let ean8 = EAN8::new("1234567");
 
         assert!(ean8.is_ok());
     }
 
     #[test]
     fn invalid_data_ean8() {
-        let ean8 = EAN8::new("1234er1".to_owned());
+        let ean8 = EAN8::new("1234er1");
 
         assert_eq!(ean8.err().unwrap(), Error::Character);
     }
 
     #[test]
     fn invalid_len_ean8() {
-        let ean8 = EAN8::new("1111112222222333333".to_owned());
+        let ean8 = EAN8::new("1111112222222333333");
 
         assert_eq!(ean8.err().unwrap(), Error::Length);
     }
 
     #[test]
     fn ean8_encode() {
-        let ean81 = EAN8::new("5512345".to_owned()).unwrap(); // Check digit: 7
-        let ean82 = EAN8::new("9834651".to_owned()).unwrap(); // Check digit: 3
+        let ean81 = EAN8::new("5512345").unwrap(); // Check digit: 7
+        let ean82 = EAN8::new("9834651").unwrap(); // Check digit: 3
 
-        assert_eq!(collapse_vec(ean81.encode()), "1010110001011000100110010010011010101000010101110010011101000100101".to_owned());
-        assert_eq!(collapse_vec(ean82.encode()), "1010001011011011101111010100011010101010000100111011001101010000101".to_owned());
+        assert_eq!(collapse_vec(ean81.encode()), "1010110001011000100110010010011010101000010101110010011101000100101");
+        assert_eq!(collapse_vec(ean82.encode()), "1010001011011011101111010100011010101010000100111011001101010000101");
     }
 }

--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -152,46 +152,46 @@ mod tests {
 
     #[test]
     fn new_ean2() {
-        let ean2 = EANSUPP::new("12".to_owned());
+        let ean2 = EANSUPP::new("12");
 
         assert!(ean2.is_ok());
     }
 
     #[test]
     fn new_ean5() {
-        let ean5 = EANSUPP::new("12345".to_owned());
+        let ean5 = EANSUPP::new("12345");
 
         assert!(ean5.is_ok());
     }
 
     #[test]
     fn invalid_data_ean2() {
-        let ean2 = EANSUPP::new("AT".to_owned());
+        let ean2 = EANSUPP::new("AT");
 
         assert_eq!(ean2.err().unwrap(), Error::Character);
     }
 
     #[test]
     fn invalid_len_ean2() {
-        let ean2 = EANSUPP::new("123".to_owned());
+        let ean2 = EANSUPP::new("123");
 
         assert_eq!(ean2.err().unwrap(), Error::Length);
     }
 
     #[test]
     fn ean2_encode() {
-        let ean21 = EANSUPP::new("34".to_owned()).unwrap();
+        let ean21 = EANSUPP::new("34").unwrap();
 
         assert_eq!(collapse_vec(ean21.encode()),
-                   "10110100001010100011".to_owned());
+                   "10110100001010100011");
     }
 
     #[test]
     fn ean5_encode() {
-        let ean51 = EANSUPP::new("51234".to_owned()).unwrap();
+        let ean51 = EANSUPP::new("51234").unwrap();
 
         assert_eq!(collapse_vec(ean51.encode()),
-                   "10110110001010011001010011011010111101010011101".to_owned());
+                   "10110110001010011001010011011010111101010011101");
     }
 
 }

--- a/src/sym/mod.rs
+++ b/src/sym/mod.rs
@@ -7,7 +7,7 @@
 //! ```rust
 //! use barcoders::sym::ean13::*;
 //!
-//! let barcode = EAN13::new("750103131130".to_owned()).unwrap();
+//! let barcode = EAN13::new("750103131130").unwrap();
 //! let encoded = barcode.encode();
 //! ```
 //! Each encoder accepts a `String` to be encoded. Valid data is barcode-specific and thus


### PR DESCRIPTION
All of these places are happy with the resulting AsRef<str>.