### PR TITLE
Update image dependency to 0.22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,5 +21,5 @@ svg = []
 dev = ["clippy"]
 
 [dependencies]
-image = {version = "0.18.0", optional = true}
+image = {version = "0.22", optional = true}
 clippy = {version = "0.0.166", optional = true}

--- a/src/generators/image.rs
+++ b/src/generators/image.rs
@@ -158,7 +158,7 @@ impl Image {
         let mut bytes: Vec<u8> = vec![];
         let img = self.place_pixels(&barcode);
 
-        match img.save(&mut bytes, format) {
+        match img.write_to(&mut bytes, format) {
             Ok(_) => Ok(bytes),
             _ => Err(Error::Generate),
         }


### PR DESCRIPTION
I play with qrcode package and found that it uses different version of `image`, so I decided to update this one