### PR TITLE
Cargo clippy updates

### DIFF
--- a/src/generators/svg.rs
+++ b/src/generators/svg.rs
@@ -124,7 +124,7 @@ impl SVG {
         let rects: String = barcode.iter()
             .enumerate()
             .filter(|&(_, &n)| n == 1)
-            .map(|(i, &n)| self.rect(n, (i as u32 * self.xdim), self.xdim))
+            .map(|(i, &n)| self.rect(n, i as u32 * self.xdim, self.xdim))
             .collect();
 
         Ok(format!("<svg version=\"1.1\" viewBox=\"0 0 {w} {h}\">{s}{r}</svg>",

--- a/src/sym/codabar.rs
+++ b/src/sym/codabar.rs
@@ -23,8 +23,8 @@ enum Unit {
 }
 
 impl Unit {
-    fn lookup(&self) -> Vec<u8> {
-        match *self {
+    fn lookup(self) -> Vec<u8> {
+        match self {
             Unit::Zero => vec![1,0,1,0,1,0,0,1,1],
             Unit::One => vec![1,0,1,0,1,1,0,0,1],
             Unit::Two => vec![1,0,1,0,0,1,0,1,1],

--- a/src/sym/code11.rs
+++ b/src/sym/code11.rs
@@ -48,7 +48,7 @@ impl Code11 {
     }
 
     /// Calculates a checksum character using a weighted modulo-11 algorithm.
-    fn checksum_char(&self, data: &Vec<char>, weight_threshold: usize) -> Option<char> {
+    fn checksum_char(&self, data: &[char], weight_threshold: usize) -> Option<char> {
         let get_char_pos = |&c| CHARS.iter().position(|t| t.0 == c).unwrap();
         let weight = |i| {
             match i % weight_threshold {

--- a/src/sym/code128.rs
+++ b/src/sym/code128.rs
@@ -162,8 +162,8 @@ impl CharacterSet {
         }
     }
 
-    fn unit(&self, n: usize) -> Result<Unit> {
-        match *self {
+    fn unit(self, n: usize) -> Result<Unit> {
+        match self {
             CharacterSet::A => Ok(Unit::A(n)),
             CharacterSet::B => Ok(Unit::B(n)),
             CharacterSet::C => Ok(Unit::C(n)),
@@ -171,8 +171,8 @@ impl CharacterSet {
         }
     }
 
-    fn index(&self) -> Result<usize> {
-        match *self {
+    fn index(self) -> Result<usize> {
+        match self {
             CharacterSet::A => Ok(0),
             CharacterSet::B => Ok(1),
             CharacterSet::C => Ok(2),
@@ -180,7 +180,7 @@ impl CharacterSet {
         }
     }
 
-    fn lookup(&self, s: &str) -> Result<Unit> {
+    fn lookup(self, s: &str) -> Result<Unit> {
         let p = self.index()?;
 
         match CHARS.iter().position(|&c| c.0[p] == s) {
@@ -257,7 +257,7 @@ impl Code128 {
     fn checksum_value(&self) -> u8 {
         let sum: i32 = self.0
                            .iter()
-                           .zip((0..self.0.len() as i32))
+                           .zip(0..self.0.len() as i32)
                            .fold(0, |t, (u, i)| t + (u.index() as i32 * cmp::max(1, i)));
 
         (sum % 103) as u8

--- a/src/sym/code39.rs
+++ b/src/sym/code39.rs
@@ -45,7 +45,7 @@ impl Code39 {
         Code39::parse(data).and_then(|d| {
             Ok(Code39 {
                 data: d.chars().collect(),
-                checksum: checksum,
+                checksum,
             })
         })
     }
@@ -66,7 +66,7 @@ impl Code39 {
     fn checksum_char(&self) -> Option<char> {
         let get_char_pos = |&c| CHARS.iter().position(|t| t.0 == c).unwrap();
         let indices = self.data.iter().map(&get_char_pos);
-        let index = indices.fold(0, |acc, i| acc + i) % CHARS.len();
+        let index = indices.sum::<usize>() % CHARS.len();
 
         match CHARS.get(index) {
             Some(&(c, _)) => Some(c),
@@ -76,13 +76,13 @@ impl Code39 {
 
     fn checksum_encoding(&self) -> [u8; 12] {
         match self.checksum_char() {
-            Some(c) => self.char_encoding(&c),
+            Some(c) => self.char_encoding(c),
             None => panic!("Cannot compute checksum"),
         }
     }
 
-    fn char_encoding(&self, c: &char) -> [u8; 12] {
-        match CHARS.iter().find(|&ch| ch.0 == *c) {
+    fn char_encoding(&self, c: char) -> [u8; 12] {
+        match CHARS.iter().find(|&ch| ch.0 == c) {
             Some(&(_, enc)) => enc,
             None => panic!(format!("Unknown char: {}", c)),
         }
@@ -99,7 +99,7 @@ impl Code39 {
         let mut enc = vec![0];
 
         for c in &self.data {
-            self.push_encoding(&mut enc, self.char_encoding(&c));
+            self.push_encoding(&mut enc, self.char_encoding(*c));
         }
 
         if self.checksum {

--- a/src/sym/code93.rs
+++ b/src/sym/code93.rs
@@ -59,7 +59,7 @@ impl Code93 {
     }
 
     /// Calculates a checksum character using a weighted modulo-47 algorithm.
-    fn checksum_char(&self, data: &Vec<char>, weight_threshold: usize) -> Option<char> {
+    fn checksum_char(&self, data: &[char], weight_threshold: usize) -> Option<char> {
         let get_char_pos = |&c| CHARS.iter().position(|t| t.0 == c).unwrap();
         let weight = |i| {
             match (data.len() - i) % weight_threshold {

--- a/src/sym/ean13.rs
+++ b/src/sym/ean13.rs
@@ -84,15 +84,15 @@ impl EAN13 {
     }
 
     fn number_system_encoding(&self) -> [u8; 7] {
-        self.char_encoding(0, &self.number_system_digit())
+        self.char_encoding(0, self.number_system_digit())
     }
 
     fn checksum_encoding(&self) -> [u8; 7] {
-        self.char_encoding(2, &self.checksum_digit())
+        self.char_encoding(2, self.checksum_digit())
     }
 
-    fn char_encoding(&self, side: usize, d: &u8) -> [u8; 7] {
-        ENCODINGS[side][*d as usize]
+    fn char_encoding(&self, side: usize, d: u8) -> [u8; 7] {
+        ENCODINGS[side][d as usize]
     }
 
     fn left_digits(&self) -> &[u8] {
@@ -111,7 +111,7 @@ impl EAN13 {
         let slices: Vec<[u8; 7]> = self.left_digits()
                                        .iter()
                                        .zip(self.parity_mapping().iter())
-                                       .map(|(d, s)| self.char_encoding(*s, &d))
+                                       .map(|(d, s)| self.char_encoding(*s, *d))
                                        .collect();
 
         helpers::join_iters(slices.iter())
@@ -120,7 +120,7 @@ impl EAN13 {
     fn right_payload(&self) -> Vec<u8> {
         let slices: Vec<[u8; 7]> = self.right_digits()
                                        .iter()
-                                       .map(|d| self.char_encoding(2, &d))
+                                       .map(|d| self.char_encoding(2, *d))
                                        .collect();
 
         helpers::join_iters(slices.iter())
@@ -147,7 +147,7 @@ impl Parse for EAN13 {
 
     /// Returns the set of valid characters allowed in this type of barcode.
     fn valid_chars() -> Vec<char> {
-        (0..10).into_iter().map(|i| char::from_digit(i, 10).unwrap()).collect()
+        (0..10).map(|i| char::from_digit(i, 10).unwrap()).collect()
     }
 }
 

--- a/src/sym/ean8.rs
+++ b/src/sym/ean8.rs
@@ -41,18 +41,18 @@ impl EAN8 {
         let mut ns = vec![];
 
         for d in self.number_system_digits() {
-            ns.extend(self.char_encoding(0, &d).iter().cloned());
+            ns.extend(self.char_encoding(0, *d).iter().cloned());
         }
 
         ns
     }
 
     fn checksum_encoding(&self) -> [u8; 7] {
-        self.char_encoding(2, &self.checksum_digit())
+        self.char_encoding(2, self.checksum_digit())
     }
 
-    fn char_encoding(&self, side: usize, d: &u8) -> [u8; 7] {
-        ENCODINGS[side][*d as usize]
+    fn char_encoding(&self, side: usize, d: u8) -> [u8; 7] {
+        ENCODINGS[side][d as usize]
     }
 
     fn left_digits(&self) -> &[u8] {
@@ -66,7 +66,7 @@ impl EAN8 {
     fn left_payload(&self) -> Vec<u8> {
         let slices: Vec<[u8; 7]> = self.left_digits()
                                        .iter()
-                                       .map(|d| self.char_encoding(0, &d))
+                                       .map(|d| self.char_encoding(0, *d))
                                        .collect();
 
         helpers::join_iters(slices.iter())
@@ -75,7 +75,7 @@ impl EAN8 {
     fn right_payload(&self) -> Vec<u8> {
         let slices: Vec<[u8; 7]> = self.right_digits()
                                        .iter()
-                                       .map(|d| self.char_encoding(2, &d))
+                                       .map(|d| self.char_encoding(2, *d))
                                        .collect();
 
         helpers::join_iters(slices.iter())
@@ -102,7 +102,7 @@ impl Parse for EAN8 {
 
     /// Returns the set of valid characters allowed in this type of barcode.
     fn valid_chars() -> Vec<char> {
-        (0..10).into_iter().map(|i| char::from_digit(i, 10).unwrap()).collect()
+        (0..10).map(|i| char::from_digit(i, 10).unwrap()).collect()
     }
 }
 

--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -63,8 +63,8 @@ impl EANSUPP {
         }
     }
 
-    fn char_encoding(&self, side: usize, d: &u8) -> [u8; 7] {
-        ENCODINGS[side][*d as usize]
+    fn char_encoding(&self, side: usize, d: u8) -> [u8; 7] {
+        ENCODINGS[side][d as usize]
     }
 
     /// Calculates the checksum digit using a modified modulo-10 weighting
@@ -105,7 +105,7 @@ impl EANSUPP {
         let slices: Vec<[u8; 7]> = self.raw_data()
                                        .iter()
                                        .zip(self.parity().iter())
-                                       .map(|(d, s)| self.char_encoding(*s, &d))
+                                       .map(|(d, s)| self.char_encoding(*s, *d))
                                        .collect();
 
         for (i, d) in slices.iter().enumerate() {
@@ -135,7 +135,7 @@ impl Parse for EANSUPP {
 
     /// Returns the set of valid characters allowed in this type of barcode.
     fn valid_chars() -> Vec<char> {
-        (0..10).into_iter().map(|i| char::from_digit(i, 10).unwrap()).collect()
+        (0..10).map(|i| char::from_digit(i, 10).unwrap()).collect()
     }
 }
 

--- a/src/sym/helpers.rs
+++ b/src/sym/helpers.rs
@@ -2,7 +2,7 @@
 /// TODO: Work out how to use join_iters with slices and then remove this function.
 pub fn join_slices(slices: &[&[u8]]) -> Vec<u8> {
     slices.iter()
-          .flat_map(|b| b.into_iter())
+          .flat_map(|b| b.iter())
           .cloned()
           .collect()
 }

--- a/src/sym/tf.rs
+++ b/src/sym/tf.rs
@@ -94,7 +94,7 @@ impl TF {
         encoding
     }
 
-    fn char_encoding(&self, d: &u8) -> Vec<u8> {
+    fn char_encoding(&self, d: u8) -> Vec<u8> {
         let bars: Vec<Vec<u8>> = self.char_widths(d)
                                      .chars()
                                      .map(|c| {
@@ -108,15 +108,15 @@ impl TF {
         helpers::join_iters(bars.iter())
     }
 
-    fn char_widths(&self, d: &u8) -> &'static str {
-        WIDTHS[*d as usize]
+    fn char_widths(&self, d: u8) -> &'static str {
+        WIDTHS[d as usize]
     }
 
     fn stf_payload(&self) -> Vec<u8> {
         let mut encodings = vec![];
 
         for d in self.raw_data() {
-            encodings.extend(self.char_encoding(d).iter().cloned());
+            encodings.extend(self.char_encoding(*d).iter().cloned());
         }
 
         encodings
@@ -154,7 +154,7 @@ impl Parse for TF {
 
     /// Returns the set of valid characters allowed in this type of barcode.
     fn valid_chars() -> Vec<char> {
-        (0..10).into_iter().map(|i| char::from_digit(i, 10).unwrap()).collect()
+        (0..10).map(|i| char::from_digit(i, 10).unwrap()).collect()
     }
 }
 


### PR DESCRIPTION
Following things have been updated:

* 10 warnings: this argument is passed by reference, but would be more efficient if passed by value: https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref
* 4 warnings: identical conversion: https://rust-lang.github.io/rust-clippy/master/index.html#identity_conversion
* 2 warnings: writing `&Vec<_>` instead of `&[_]` involves one more reference and cannot be used with non-Vec-based slices: https://rust-lang.github.io/rust-clippy/master/index.html#ptr_arg
* 1 warning: unnecessary parentheses around method argument
* 1 warning: this `.fold` can be written more succinctly using another method: https://rust-lang.github.io/rust-clippy/master/index.html#unnecessary_fold
* 1 warning: this .into_iter() call is equivalent to .iter() and will not move the slice: https://rust-lang.github.io/rust-clippy/master/index.html#into_iter_on_ref
* 1 warning: redundant field names in struct initialization
* 1 warning: Consider removing unnecessary double parentheses