### PR TITLE
Migrate crate to 2018 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "barcoders"
 version = "1.0.1"
+edition = "2018"
 authors = ["Andrew Buntine <info@bunts.io>"]
 description = "A barcode-encoding library"
 homepage = "https://github.com/buntine/barcoders"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ exclude = [
 ascii = []
 json = []
 svg = []
-dev = ["clippy"]
 
 [dependencies]
 image = {version = "0.22", optional = true}
-clippy = {version = "0.0.166", optional = true}

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -18,7 +18,7 @@ pub enum Error {
 pub type Result<T> = ::std::result::Result<T, Error>;
 
 impl fmt::Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.write_str(self.description())
     }
 }

--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -32,7 +32,7 @@ impl StdError for Error {
         }
     }
 
-    fn cause(&self) -> Option<&StdError> {
+    fn cause(&self) -> Option<&dyn StdError> {
         None
     }
 }

--- a/src/generators/ascii.rs
+++ b/src/generators/ascii.rs
@@ -6,7 +6,7 @@
 //! or running the test suite.
 
 use std::iter::repeat;
-use error::Result;
+use crate::error::Result;
 
 /// The ASCII barcode generator type.
 #[derive(Copy, Clone, Debug)]
@@ -55,16 +55,16 @@ impl ASCII {
 
 #[cfg(test)]
 mod tests {
-    use ::sym::ean13::*;
-    use ::sym::ean8::*;
-    use ::sym::ean_supp::*;
-    use ::sym::code39::*;
-    use ::sym::code93::*;
-    use ::sym::code11::*;
-    use ::sym::code128::*;
-    use ::sym::tf::*;
-    use ::sym::codabar::*;
-    use ::generators::ascii::*;
+    use crate::sym::ean13::*;
+    use crate::sym::ean8::*;
+    use crate::sym::ean_supp::*;
+    use crate::sym::code39::*;
+    use crate::sym::code93::*;
+    use crate::sym::code11::*;
+    use crate::sym::code128::*;
+    use crate::sym::tf::*;
+    use crate::sym::codabar::*;
+    use crate::generators::ascii::*;
 
     #[test]
     fn ean_13_as_ascii() {

--- a/src/generators/image.rs
+++ b/src/generators/image.rs
@@ -21,7 +21,7 @@
 //!
 //! See the README for more examples.
 
-extern crate image;
+use image;
 
 use image::{ImageBuffer, Rgba, ImageRgba8, DynamicImage};
 use crate::error::{Result, Error};
@@ -205,7 +205,7 @@ impl Image {
 
 #[cfg(test)]
 mod tests {
-    extern crate image;
+    
 
     use crate::sym::ean13::*;
     use crate::sym::ean8::*;

--- a/src/generators/image.rs
+++ b/src/generators/image.rs
@@ -24,7 +24,7 @@
 extern crate image;
 
 use image::{ImageBuffer, Rgba, ImageRgba8, DynamicImage};
-use error::{Result, Error};
+use crate::error::{Result, Error};
  
 macro_rules! image_variants {
     ( $( #[$attr:meta] $v:ident ),* ) => {
@@ -207,16 +207,16 @@ impl Image {
 mod tests {
     extern crate image;
 
-    use sym::ean13::*;
-    use sym::ean8::*;
-    use sym::code39::*;
-    use sym::code93::*;
-    use sym::code11::*;
-    use sym::code128::*;
-    use sym::ean_supp::*;
-    use sym::tf::*;
-    use sym::codabar::*;
-    use generators::image::*;
+    use crate::sym::ean13::*;
+    use crate::sym::ean8::*;
+    use crate::sym::code39::*;
+    use crate::sym::code93::*;
+    use crate::sym::code11::*;
+    use crate::sym::code128::*;
+    use crate::sym::ean_supp::*;
+    use crate::sym::tf::*;
+    use crate::sym::codabar::*;
+    use crate::generators::image::*;
     use std::io::prelude::*;
     use std::io::BufWriter;
     use std::fs::File;

--- a/src/generators/json.rs
+++ b/src/generators/json.rs
@@ -11,7 +11,7 @@
 //! }
 //! ```
 
-use error::Result;
+use crate::error::Result;
 
 /// The JSON  barcode generator type.
 #[derive(Copy, Clone, Debug)]
@@ -57,16 +57,16 @@ impl JSON {
 
 #[cfg(test)]
 mod tests {
-    use ::sym::ean13::*;
-    use ::sym::ean8::*;
-    use ::sym::ean_supp::*;
-    use ::sym::code39::*;
-    use ::sym::code93::*;
-    use ::sym::code11::*;
-    use ::sym::code128::*;
-    use ::sym::tf::*;
-    use ::sym::codabar::*;
-    use ::generators::json::*;
+    use crate::sym::ean13::*;
+    use crate::sym::ean8::*;
+    use crate::sym::ean_supp::*;
+    use crate::sym::code39::*;
+    use crate::sym::code93::*;
+    use crate::sym::code11::*;
+    use crate::sym::code128::*;
+    use crate::sym::tf::*;
+    use crate::sym::codabar::*;
+    use crate::generators::json::*;
 
     #[test]
     fn ean_13_as_json() {

--- a/src/generators/svg.rs
+++ b/src/generators/svg.rs
@@ -18,7 +18,7 @@
 //! let svg = SVG::new(100);
 //! ```
 
-use error::Result;
+use crate::error::Result;
 
 trait ToHex {
     fn to_hex(&self) -> String;
@@ -134,16 +134,16 @@ impl SVG {
 
 #[cfg(test)]
 mod tests {
-    use ::sym::ean13::*;
-    use ::sym::ean8::*;
-    use ::sym::code39::*;
-    use ::sym::code93::*;
-    use ::sym::code11::*;
-    use ::sym::code128::*;
-    use ::sym::ean_supp::*;
-    use ::sym::tf::*;
-    use ::sym::codabar::*;
-    use ::generators::svg::*;
+    use crate::sym::ean13::*;
+    use crate::sym::ean8::*;
+    use crate::sym::code39::*;
+    use crate::sym::code93::*;
+    use crate::sym::code11::*;
+    use crate::sym::code128::*;
+    use crate::sym::ean_supp::*;
+    use crate::sym::tf::*;
+    use crate::sym::codabar::*;
+    use crate::generators::svg::*;
     use std::io::prelude::*;
     use std::io::BufWriter;
     use std::fs::File;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,12 +49,6 @@
         unstable_features,
         unused_import_braces, unused_qualifications)]
 
-#![cfg_attr(feature = "dev", allow(unstable_features))]
-#![cfg_attr(feature = "dev", feature(plugin))]
-#![cfg_attr(feature = "dev", plugin(clippy))]
-
-
-
 pub mod error;
 pub mod sym;
 pub mod generators;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,8 +53,7 @@
 #![cfg_attr(feature = "dev", feature(plugin))]
 #![cfg_attr(feature = "dev", plugin(clippy))]
 
-#[cfg(feature = "image")]
-extern crate image;
+
 
 pub mod error;
 pub mod sym;

--- a/src/sym/codabar.rs
+++ b/src/sym/codabar.rs
@@ -7,8 +7,8 @@
 //! Barcodes of this variant should start and end with either A, B, C, or D depending on
 //! the industry.
 
-use sym::Parse;
-use error::Result;
+use crate::sym::Parse;
+use crate::error::Result;
 use std::ops::Range;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -126,8 +126,8 @@ impl Parse for Codabar {
 
 #[cfg(test)]
 mod tests {
-    use sym::codabar::*;
-    use error::Error;
+    use crate::sym::codabar::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {

--- a/src/sym/code11.rs
+++ b/src/sym/code11.rs
@@ -6,8 +6,8 @@
 //! Code11 is a discrete symbology. This encoder always provides a C checksum. For barcodes longer
 //! than 10 characters, a second checksum digit (K) is appended.
 
-use sym::{Parse, helpers};
-use error::Result;
+use crate::sym::{Parse, helpers};
+use crate::error::Result;
 use std::ops::Range;
 
 // Character -> Binary mappings for each of the allowable characters.
@@ -137,8 +137,8 @@ impl Parse for Code11 {
 
 #[cfg(test)]
 mod tests {
-    use sym::code11::*;
-    use error::Error;
+    use crate::sym::code11::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {

--- a/src/sym/code128.rs
+++ b/src/sym/code128.rs
@@ -52,8 +52,8 @@
 //! - FNC4: ```ż``` (```\u{017C}```)
 //! - SHIFT: ```Ž``` (```\u{017D}```)
 
-use sym::helpers;
-use error::*;
+use crate::sym::helpers;
+use crate::error::*;
 
 use std::cmp;
 
@@ -293,8 +293,8 @@ impl Code128 {
 
 #[cfg(test)]
 mod tests {
-    use sym::code128::*;
-    use error::Error;
+    use crate::sym::code128::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {

--- a/src/sym/code39.rs
+++ b/src/sym/code39.rs
@@ -6,8 +6,8 @@
 //! popular in non-retail environments. It was one of the first symbologies to support encoding
 //! of the ASCII alphabet.
 
-use sym::{Parse, helpers};
-use error::Result;
+use crate::sym::{Parse, helpers};
+use crate::error::Result;
 use std::ops::Range;
 
 // Character -> Binary mappings for each of the 43 allowable character.
@@ -131,8 +131,8 @@ impl Parse for Code39 {
 
 #[cfg(test)]
 mod tests {
-    use sym::code39::*;
-    use error::Error;
+    use crate::sym::code39::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {

--- a/src/sym/code93.rs
+++ b/src/sym/code93.rs
@@ -8,8 +8,8 @@
 //! NOTE: This encoder currently only supports the basic Code93 implementation and not full-ASCII
 //! mode.
 
-use sym::{Parse, helpers};
-use error::Result;
+use crate::sym::{Parse, helpers};
+use crate::error::Result;
 use std::ops::Range;
 
 // Character -> Binary mappings for each of the 47 allowable character.
@@ -138,8 +138,8 @@ impl Parse for Code93 {
 
 #[cfg(test)]
 mod tests {
-    use sym::code93::*;
-    use error::Error;
+    use crate::sym::code93::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {

--- a/src/sym/ean13.rs
+++ b/src/sym/ean13.rs
@@ -9,8 +9,8 @@
 //!   * Bookland
 //!   * JAN
 
-use sym::{Parse, helpers};
-use error::Result;
+use crate::sym::{Parse, helpers};
+use crate::error::Result;
 use std::ops::Range;
 use std::char;
 
@@ -153,9 +153,9 @@ impl Parse for EAN13 {
 
 #[cfg(test)]
 mod tests {
-    use ::sym::ean13::*;
+    use crate::sym::ean13::*;
     use std::char;
-    use error::Error;
+    use crate::error::Error;
 
     fn collapse_vec(v: Vec<u8>) -> String {
         let chars = v.iter().map(|d| char::from_digit(*d as u32, 10).unwrap());

--- a/src/sym/ean8.rs
+++ b/src/sym/ean8.rs
@@ -3,9 +3,9 @@
 //! EAN-8 barcodes are EAN style barcodes for smaller packages on products like
 //! cigaretts, chewing gum, etc where package space is limited.
 
-use sym::{Parse, helpers};
-use error::Result;
-use sym::ean13::{ENCODINGS,
+use crate::sym::{Parse, helpers};
+use crate::error::Result;
+use crate::sym::ean13::{ENCODINGS,
                  LEFT_GUARD,
                  MIDDLE_GUARD,
                  RIGHT_GUARD};
@@ -108,8 +108,8 @@ impl Parse for EAN8 {
 
 #[cfg(test)]
 mod tests {
-    use sym::ean8::*;
-    use error::Error;
+    use crate::sym::ean8::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {

--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -6,9 +6,9 @@
 //!
 //! These supplemental barcodes never appear without a full EAN-13 barcode alongside them.
 
-use sym::{Parse, helpers};
-use error::{Error, Result};
-use sym::ean13::ENCODINGS;
+use crate::sym::{Parse, helpers};
+use crate::error::{Error, Result};
+use crate::sym::ean13::ENCODINGS;
 use std::ops::Range;
 use std::char;
 
@@ -141,8 +141,8 @@ impl Parse for EANSUPP {
 
 #[cfg(test)]
 mod tests {
-    use sym::ean_supp::*;
-    use error::Error;
+    use crate::sym::ean_supp::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {

--- a/src/sym/mod.rs
+++ b/src/sym/mod.rs
@@ -26,7 +26,7 @@ mod helpers;
 
 use std::ops::Range;
 use std::iter::Iterator;
-use error::Error;
+use crate::error::Error;
 
 trait Parse {
     fn valid_chars() -> Vec<char>;

--- a/src/sym/tf.rs
+++ b/src/sym/tf.rs
@@ -7,9 +7,9 @@
 //!
 //! Most of the time you will want to use the interleaved barcode over the standard option.
 
-use sym::Parse;
-use sym::helpers;
-use error::Result;
+use crate::sym::Parse;
+use crate::sym::helpers;
+use crate::error::Result;
 use std::ops::Range;
 use std::char;
 
@@ -160,8 +160,8 @@ impl Parse for TF {
 
 #[cfg(test)]
 mod tests {
-    use sym::tf::*;
-    use error::Error;
+    use crate::sym::tf::*;
+    use crate::error::Error;
     use std::char;
 
     fn collapse_vec(v: Vec<u8>) -> String {


### PR DESCRIPTION
This migrates the crate to the [2018 edition](https://doc.rust-lang.org/edition-guide/editions/transitioning-an-existing-project-to-a-new-edition.html).

With the 2018 edition enabled, this now produces a new deprecation warning:

```rust
warning: use of deprecated item 'std::error::Error::description': use the Display impl or to_string()
  --> src/error/mod.rs:22:26
   |
22 |         f.write_str(self.description())
   |                          ^^^^^^^^^^^
   |
```

Let me know if I should fix that as well.
