### PR TITLE
Updated dependency on `image` 0.22 to 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "barcoders"
-version = "1.0.2"
+version = "1.0.3"
 authors = ["Andrew Buntine <info@bunts.io>"]
 description = "A barcode-encoding library"
 homepage = "https://github.com/buntine/barcoders"
@@ -21,5 +21,5 @@ svg = []
 dev = ["clippy"]
 
 [dependencies]
-image = {version = "0.22", optional = true}
+image = {version = "0.23", optional = true}
 clippy = {version = "0.0.166", optional = true}


### PR DESCRIPTION
 (because of Rust security advisory https://rustsec.org/advisories/RUSTSEC-2020-0073) - see issue #21 

