### PR TITLE
Check the checksum digit if provided.

### DIFF
--- a/src/error/mod.rs
+++ b/src/error/mod.rs
@@ -12,6 +12,8 @@ pub enum Error {
     Length,
     /// An error during barcode generation.
     Generate,
+    /// Invalid checksum.
+    Checksum,
 }
 
 /// Alias-type for Result<T, barcoders::error::Error>.
@@ -23,6 +25,7 @@ impl fmt::Display for Error {
             Error::Character => write!(f, "Barcode data is invalid"),
             Error::Length => write!(f, "Barcode data length is invalid"),
             Error::Generate => write!(f, "Could not generate barcode data"),
+            Error::Checksum => write!(f, "Invalid checksum"),
         }
     }
 }

--- a/src/sym/ean8.rs
+++ b/src/sym/ean8.rs
@@ -3,7 +3,7 @@
 //! EAN-8 barcodes are EAN style barcodes for smaller packages on products like
 //! cigaretts, chewing gum, etc where package space is limited.
 
-use crate::error::Result;
+use crate::error::{Error, Result};
 use crate::sym::ean13::{ENCODINGS, LEFT_GUARD, MIDDLE_GUARD, RIGHT_GUARD};
 use crate::sym::{helpers, Parse};
 use std::char;
@@ -15,15 +15,22 @@ pub struct EAN8(Vec<u8>);
 
 impl EAN8 {
     /// Creates a new barcode.
-    /// Returns Result<EAN8, String> indicating parse success.
+    /// Returns Result<EAN8, Error> indicating parse success.
     pub fn new<T: AsRef<str>>(data: T) -> Result<EAN8> {
-        EAN8::parse(data.as_ref()).map(|d| {
-            let digits = d
-                .chars()
-                .map(|c| c.to_digit(10).expect("Unknown character") as u8)
-                .collect();
-            EAN8(digits)
-        })
+        let d = EAN8::parse(data.as_ref())?;
+        let digits: Vec<u8> = d
+            .chars()
+            .map(|c| c.to_digit(10).expect("Unknown character") as u8)
+            .collect();
+
+        let ean8 = EAN8(digits[0..7].to_vec());
+
+        // If checksum digit is provided, check the checksum.
+        if digits.len() == 8 && ean8.checksum_digit() != digits[7] {
+            return Err(Error::Checksum);
+        }
+
+        return Ok(ean8);
     }
 
     /// Calculates the checksum digit using a weighting algorithm.
@@ -140,6 +147,13 @@ mod tests {
         let ean8 = EAN8::new("1111112222222333333");
 
         assert_eq!(ean8.err().unwrap(), Error::Length);
+    }
+
+    #[test]
+    fn invalid_checksum_ean8() {
+        let ean8: std::result::Result<EAN8, Error> = EAN8::new("88023020");
+
+        assert_eq!(ean8.err().unwrap(), Error::Checksum)
     }
 
     #[test]


### PR DESCRIPTION
https://github.com/buntine/barcoders/issues/23

If the checksum digit(13th for EAN13, 8th for EAN8) is provided, it should be used only for validation. 

I'm not familiar with Rust, so please advise if there's errors.
