### PR TITLE
Only enable supported image formats

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,3 +26,5 @@ std = []
 [dependencies.image]
 version = "0.25"
 optional = true
+default-features = false
+features = ["gif", "png", "webp"]


### PR DESCRIPTION
This drops a lot of unused dependencies.