### PR TITLE
Make UPCA standards compliant

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,9 +10,9 @@
 //! ### Symbologies
 //!
 //! * EAN-13
-//!   * UPC-A
 //!   * JAN
 //!   * Bookland
+//! * UPC-A
 //! * EAN-8
 //! * EAN Supplementals
 //!   * EAN-2

--- a/src/sym.rs
+++ b/src/sym.rs
@@ -21,6 +21,7 @@ pub mod code93;
 pub mod ean13;
 pub mod ean8;
 pub mod ean_supp;
+pub mod upca;
 mod helpers;
 pub mod tf;
 #[cfg(not(feature = "std"))]


### PR DESCRIPTION
Before this change, UPCA codes were encoded like EAN-13 (see #39 ) This means that there is an extra digit and fluff that shouldn't be encoded and makes the barcode noncompliant to the original UPCA specification.

* Remove type alias where UPCA == EAN-13
* Bring in UPCA type that conforms to the UPCA specification
* Add a few test cases to verify functionality

---

I've opted to break out UPCA into a new module instead of extending EAN-13.  If it's preferred, I'd be happy to refactor so that they're more tightly integrated