### PR TITLE
Correct EAN5 checksum table

### DIFF
--- a/src/sym/ean_supp.rs
+++ b/src/sym/ean_supp.rs
@@ -17,7 +17,7 @@ const LEFT_GUARD: [u8; 4] = [1, 0, 1, 1];
 
 /// Maps parity (odd/even) for the EAN-5 barcodes based on the check digit.
 const EAN5_PARITY: [[usize; 5]; 10] = [
-    [0, 0, 1, 1, 1],
+    [1, 1, 0, 0, 0],
     [1, 0, 1, 0, 0],
     [1, 0, 0, 1, 0],
     [1, 0, 0, 0, 1],


### PR DESCRIPTION
Incorrect implementation of EAN-5 barcode checksum table.
For checksum value `0` there is incorrect combination of odd/even number coding.

Due to this bug EAN-5 barcode for some values (example: "30755") are incorrect encoded.

Checksum table from EAN-5 standard:
![EAN-5 checksum](https://github.com/user-attachments/assets/f7f267f6-1029-476a-94ac-1879aa6d52e9)
